### PR TITLE
Fix document upload failing with empty mimeType

### DIFF
--- a/server/routers.ts
+++ b/server/routers.ts
@@ -1788,13 +1788,14 @@ export const appRouter = router({
         tags: z.array(z.string()).optional(),
       }))
       .mutation(async ({ input, ctx }) => {
-        const { fileData, mimeType, ...docData } = input;
-        
+        const { fileData, mimeType: inputMimeType, ...docData } = input;
+        const mimeType = inputMimeType || 'application/octet-stream';
+
         // Decode base64 and upload to S3
         const buffer = Buffer.from(fileData, 'base64');
         const fileKey = `documents/${ctx.user.id}/${nanoid()}-${input.name}`;
         const { url } = await storagePut(fileKey, buffer, mimeType);
-        
+
         const result = await db.createDocument({
           ...docData,
           fileUrl: url,


### PR DESCRIPTION
When uploading files with unrecognized extensions, the browser returns
an empty string for file.type. The documents.upload endpoint was passing
this empty string to storagePut, which caused the upload to fail.

Added fallback to 'application/octet-stream' for empty mimeType, matching
the pattern used in other upload endpoints (documentImport.parse,
supplierPortal.uploadDocument).

https://claude.ai/code/session_0113s4v53B7xucYvG5DFhH2J