### PR TITLE
Fix scanned PDF OCR to process all pages instead of only the first

### DIFF
--- a/server/documentImportService.ts
+++ b/server/documentImportService.ts
@@ -11,6 +11,7 @@ import { randomBytes } from "crypto";
 
 // Configuration constants
 const MIN_TEXT_LENGTH_FOR_SCANNED_DETECTION = 100; // Minimum text length to consider PDF as text-based
+const MAX_SCANNED_PDF_PAGES = 10; // Maximum pages to OCR for scanned PDFs (balances cost vs completeness)
 
 // Types for document import
 export interface ImportedLineItem {
@@ -361,15 +362,16 @@ If document type is unknown, return all as null.`;
         // Check if we got sufficient text (less than threshold suggests scanned/image PDF)
         if (fullText.trim().length < MIN_TEXT_LENGTH_FOR_SCANNED_DETECTION) {
           console.log("[DocumentImport] Insufficient text extracted, PDF appears to be scanned. Falling back to OCR...");
-          
-          // Log warning for multi-page PDFs
-          if (pdf.numPages > 1) {
-            console.warn(`[DocumentImport] PDF has ${pdf.numPages} pages, but only processing first page for OCR. Additional pages will be ignored.`);
+
+          const pagesToProcess = Math.min(pdf.numPages, MAX_SCANNED_PDF_PAGES);
+          if (pdf.numPages > MAX_SCANNED_PDF_PAGES) {
+            console.warn(`[DocumentImport] PDF has ${pdf.numPages} pages, capping OCR at first ${MAX_SCANNED_PDF_PAGES} pages.`);
           }
-          
+          console.log(`[DocumentImport] Processing ${pagesToProcess} page(s) for OCR`);
+
           // Create buffer for pdf2pic (only needed for scanned PDFs)
           const buffer = Buffer.from(arrayBuffer);
-          
+
           // Convert PDF to images using pdf2pic for OCR
           // Use crypto.randomBytes for unique directory name to avoid collisions
           const uniqueId = randomBytes(8).toString('hex');
@@ -377,7 +379,7 @@ If document type is unknown, return all as null.`;
           if (!existsSync(tempDir)) {
             mkdirSync(tempDir, { recursive: true });
           }
-          
+
           try {
             const options = {
               density: 200, // DPI for image conversion
@@ -387,29 +389,37 @@ If document type is unknown, return all as null.`;
               width: 2000,
               height: 2800
             };
-            
+
             console.log("[DocumentImport] Converting PDF to images for OCR...");
             const convert = fromBuffer(buffer, options);
-            
+
             // Configure to use ImageMagick (not GraphicsMagick)
             convert.setGMClass(true); // true = use ImageMagick
-            
-            // Convert first page to base64 for vision OCR (limiting to first page for efficiency)
-            const pageResult = await convert(1, { responseType: "base64" });
-            
-            if (!pageResult || !pageResult.base64) {
-              throw new Error("PDF to image conversion failed");
+
+            // Convert all pages to base64 for vision OCR
+            const imageContents: any[] = [];
+            for (let pageNum = 1; pageNum <= pagesToProcess; pageNum++) {
+              const pageResult = await convert(pageNum, { responseType: "base64" });
+              if (!pageResult || !pageResult.base64) {
+                console.warn(`[DocumentImport] Failed to convert page ${pageNum}, skipping`);
+                continue;
+              }
+              const dataUrl = `data:image/png;base64,${pageResult.base64}`;
+              imageContents.push({ type: "image_url", image_url: { url: dataUrl, detail: "high" } });
             }
-            
-            console.log("[DocumentImport] PDF converted to image, using vision OCR");
-            const dataUrl = `data:image/png;base64,${pageResult.base64}`;
-            
-            // Use vision-based OCR (similar to image processing)
+
+            if (imageContents.length === 0) {
+              throw new Error("PDF to image conversion failed for all pages");
+            }
+
+            console.log(`[DocumentImport] Converted ${imageContents.length} page(s) to images, using vision OCR`);
+
+            // Use vision-based OCR with all pages
             messageContent = [
               { type: "text", text: prompt },
-              { type: "image_url", image_url: { url: dataUrl, detail: "high" } }
+              ...imageContents
             ];
-            
+
             // Clean up temp directory using safe fs.rmSync
             try {
               rmSync(tempDir, { recursive: true, force: true });


### PR DESCRIPTION
Previously, multi-page scanned PDFs would only OCR the first page, silently dropping all content from subsequent pages. This caused incomplete data extraction for multi-page invoices, POs, and shipping documents. Now all pages are converted and sent as images to Claude Vision (capped at 10 pages to balance cost and completeness).

https://claude.ai/code/session_01WrxKVUPStABZGYkxBq3Znn

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes OCR for scanned PDFs by processing all pages (capped at 10) instead of only the first, preventing lost data on multi-page documents.

- **Bug Fixes**
  - Converts each page to PNG via `pdf2pic` and sends all images in one Vision request.
  - Caps OCR at 10 pages; logs capping and pages processed.
  - Skips pages that fail to convert; throws if all fail; cleans up temp files and uses ImageMagick.

<sup>Written for commit c7c063e469fbefc948d255aa41fdda104bea81b8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

