### PR TITLE
Cursor/meetings redesign 2122d

### DIFF
--- a/client/src/components/DashboardLayout.tsx
+++ b/client/src/components/DashboardLayout.tsx
@@ -81,6 +81,9 @@ import {
   Headphones,
   PenTool,
   UserPlus,
+  Bot,
+  Heart,
+  Building2,
 } from "lucide-react";
 import { CSSProperties, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useLocation } from "wouter";

--- a/client/src/pages/ComponentShowcase.tsx
+++ b/client/src/pages/ComponentShowcase.tsx
@@ -230,7 +230,7 @@ export default function ComponentsShowcase() {
     <div className="min-h-screen bg-background text-foreground">
       <main className="container max-w-6xl mx-auto">
         <div className="space-y-2 justify-between flex">
-          <h2 className="text-[1.875rem] font-semibold tracking-[-0.025em] mb-6">
+          <h2 className="text-lg font-semibold mb-6">
             Shadcn/ui Component Library
           </h2>
           <Button variant="outline" size="icon" onClick={toggleTheme}>

--- a/client/src/pages/Meetings.tsx
+++ b/client/src/pages/Meetings.tsx
@@ -282,12 +282,13 @@ export default function Meetings() {
                 onChange={(e) => setDateTo(e.target.value)}
               />
             </div>
-            {(search || statusFilter !== "all" || dateFrom || dateTo) && (
+            {(search || listView !== "all" || statusFilter !== "all" || dateFrom || dateTo) && (
               <Button
                 variant="ghost"
                 className="w-full"
                 onClick={() => {
                   setSearch("");
+                  setListView("all");
                   setStatusFilter("all");
                   setDateFrom("");
                   setDateTo("");

--- a/client/src/pages/ai/ApprovalQueue.tsx
+++ b/client/src/pages/ai/ApprovalQueue.tsx
@@ -121,7 +121,7 @@ export default function ApprovalQueue() {
   const { data: pendingTasks, isLoading: pendingLoading } = trpc.aiAgent.tasks.pendingApprovals.useQuery();
   const { data: allTasks, isLoading: allLoading } = trpc.aiAgent.tasks.list.useQuery({});
   const { data: logs } = trpc.aiAgent.logs.list.useQuery({ limit: 50 });
-  const { data: teamMembers } = trpc.settings.team.list.useQuery(undefined, { retry: false });
+  const { data: teamMembers } = trpc.team.list.useQuery(undefined, { retry: false });
   const { data: projects } = trpc.projects.list.useQuery();
   
   const approveMutation = trpc.aiAgent.tasks.approve.useMutation({

--- a/client/src/pages/projects/Projects.tsx
+++ b/client/src/pages/projects/Projects.tsx
@@ -35,6 +35,7 @@ import {
   Clock3,
   Check,
   AlertTriangle,
+  FolderKanban,
 } from "lucide-react";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";

--- a/client/src/pages/projects/Projects.tsx
+++ b/client/src/pages/projects/Projects.tsx
@@ -25,7 +25,6 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import {
-  FolderKanban,
   Plus,
   Search,
   Loader2,
@@ -34,7 +33,7 @@ import {
   ChevronDown,
   ChevronRight,
   Clock3,
-  CheckCircle,
+  Check,
   AlertTriangle,
 } from "lucide-react";
 import { toast } from "sonner";
@@ -79,10 +78,10 @@ type UserRecord = {
 };
 
 const PRIORITY_BADGE: Record<string, { label: string; className: string }> = {
-  critical: { label: "Critical", className: "bg-red-500/15 text-red-600 border-red-300" },
-  high: { label: "High", className: "bg-orange-500/15 text-orange-600 border-orange-300" },
-  medium: { label: "Medium", className: "bg-amber-500/15 text-amber-600 border-amber-300" },
-  low: { label: "Low", className: "bg-emerald-500/15 text-emerald-600 border-emerald-300" },
+  critical: { label: "Critical", className: "bg-muted text-foreground border-border" },
+  high: { label: "High", className: "bg-muted text-foreground border-border" },
+  medium: { label: "Medium", className: "bg-muted text-foreground border-border" },
+  low: { label: "Low", className: "bg-muted text-foreground border-border" },
 };
 
 const PRIORITY_ORDER: Record<string, number> = {
@@ -93,18 +92,18 @@ const PRIORITY_ORDER: Record<string, number> = {
 };
 
 const STATUS_META = {
-  todo: { label: "To Do", accent: "border-slate-300", badge: "bg-slate-500/10 text-slate-600" },
-  in_progress: { label: "In Progress", accent: "border-blue-300", badge: "bg-blue-500/10 text-blue-600" },
-  review: { label: "In Review", accent: "border-violet-300", badge: "bg-violet-500/10 text-violet-600" },
-  completed: { label: "Completed", accent: "border-emerald-300", badge: "bg-emerald-500/10 text-emerald-600" },
-  cancelled: { label: "Cancelled", accent: "border-zinc-300", badge: "bg-zinc-500/10 text-zinc-600" },
+  todo: { label: "To Do", accent: "border-border", badge: "bg-muted text-foreground" },
+  in_progress: { label: "In Progress", accent: "border-border", badge: "bg-muted text-foreground" },
+  review: { label: "In Review", accent: "border-border", badge: "bg-muted text-foreground" },
+  completed: { label: "Completed", accent: "border-border", badge: "bg-muted text-foreground" },
+  cancelled: { label: "Cancelled", accent: "border-border", badge: "bg-muted text-foreground" },
 } as const;
 
 const BOARD_COLUMNS = [
-  { key: "todo", label: "To Do", accent: "border-slate-300" },
-  { key: "in_progress", label: "In Progress", accent: "border-blue-300" },
-  { key: "review", label: "In Review", accent: "border-violet-300" },
-  { key: "completed", label: "Completed", accent: "border-emerald-300" },
+  { key: "todo", label: "To Do", accent: "border-border" },
+  { key: "in_progress", label: "In Progress", accent: "border-border" },
+  { key: "review", label: "In Review", accent: "border-border" },
+  { key: "completed", label: "Completed", accent: "border-border" },
 ] as const;
 
 function getUserName(users: UserRecord[] | undefined, id: number | null): string {
@@ -131,9 +130,9 @@ function daysUntilDate(d: string | Date | null | undefined): number | null {
 function dueDateColor(d: string | Date | null | undefined): string {
   const days = daysUntilDate(d);
   if (days === null) return "text-muted-foreground";
-  if (days < 0) return "text-red-600";
-  if (days <= 3) return "text-amber-600";
-  return "text-emerald-600";
+  if (days < 0) return "text-foreground";
+  if (days <= 3) return "text-foreground";
+  return "text-muted-foreground";
 }
 
 export default function Projects() {
@@ -560,7 +559,7 @@ export default function Projects() {
         </Card>
         <Card>
           <CardContent className="flex h-full items-center gap-3 p-4">
-            <Clock3 className="h-5 w-5 text-blue-600" />
+            <Clock3 className="h-5 w-5 text-muted-foreground" />
             <div>
               <p className="text-xs text-muted-foreground">In Progress</p>
               <p className="text-xl font-semibold">{metrics.inProgress}</p>
@@ -569,19 +568,19 @@ export default function Projects() {
         </Card>
         <Card>
           <CardContent className="flex h-full items-center gap-3 p-4">
-            <CheckCircle className="h-5 w-5 text-violet-600" />
+            <Check className="h-5 w-5 text-muted-foreground" />
             <div>
               <p className="text-xs text-muted-foreground">In Review</p>
               <p className="text-xl font-semibold">{metrics.review}</p>
             </div>
           </CardContent>
         </Card>
-        <Card className={cn(metrics.overdue > 0 && "border-red-300")}>
+        <Card className={cn(metrics.overdue > 0 && "border-border")}>
           <CardContent className="flex h-full items-center gap-3 p-4">
-            <AlertTriangle className={cn("h-5 w-5", metrics.overdue > 0 ? "text-red-600" : "text-muted-foreground")} />
+            <AlertTriangle className="h-5 w-5 text-muted-foreground" />
             <div>
               <p className="text-xs text-muted-foreground">Overdue</p>
-              <p className={cn("text-xl font-semibold", metrics.overdue > 0 && "text-red-600")}>{metrics.overdue}</p>
+              <p className="text-xl font-semibold">{metrics.overdue}</p>
             </div>
           </CardContent>
         </Card>
@@ -695,7 +694,6 @@ export default function Projects() {
                       ) : (
                         <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground" />
                       )}
-                      <FolderKanban className="h-4 w-4 shrink-0 text-muted-foreground" />
                       <span className="truncate font-semibold">{project?.name || `Project #${projectId}`}</span>
                       <Badge variant="secondary">{tasks.length} tasks</Badge>
                     </div>
@@ -753,7 +751,7 @@ export default function Projects() {
                             </div>
                             <div className="flex flex-wrap items-center gap-2 md:justify-end">
                               <Badge className={cn("border text-[10px] font-normal", status.badge)}>{status.label}</Badge>
-                              <Badge variant="outline" className={cn("text-[10px]", priority.className)}>
+                              <Badge variant="outline" className={cn("text-[10px] font-normal", priority.className)}>
                                 {priority.label}
                               </Badge>
                               {task.dueDate && (

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -1,4 +1,4 @@
-import { int, mysqlEnum, mysqlTable, text, timestamp, varchar, decimal, boolean, json, bigint, uniqueIndex, serial } from "drizzle-orm/mysql-core";
+import { int, mysqlEnum, mysqlTable, text, timestamp, varchar, decimal, boolean, json, bigint, uniqueIndex, serial, type AnyMySqlColumn } from "drizzle-orm/mysql-core";
 import { relations } from "drizzle-orm";
 
 // ============================================
@@ -297,7 +297,7 @@ export const accounts = mysqlTable("accounts", {
   balance: decimal("balance", { precision: 15, scale: 2 }).default("0"),
   currency: varchar("currency", { length: 3 }).default("USD"),
   isActive: boolean("isActive").default(true),
-  parentAccountId: int("parentAccountId").references(() => accounts.id),
+  parentAccountId: int("parentAccountId").references((): AnyMySqlColumn => accounts.id),
   quickbooksAccountId: varchar("quickbooksAccountId", { length: 64 }),
   createdAt: timestamp("createdAt").defaultNow().notNull(),
   updatedAt: timestamp("updatedAt").defaultNow().onUpdateNow().notNull(),
@@ -4509,6 +4509,9 @@ export const investmentGrantItems = mysqlTable("investment_grant_items", {
   updatedAt: timestamp("updatedAt").defaultNow().onUpdateNow().notNull(),
 });
 
+export type InvestmentGrantItem = typeof investmentGrantItems.$inferSelect;
+export type InsertInvestmentGrantItem = typeof investmentGrantItems.$inferInsert;
+
 // ============================================
 // EDI (ELECTRONIC DATA INTERCHANGE) MODULE
 // ============================================
@@ -4744,8 +4747,6 @@ export const ediSettings = mysqlTable("edi_settings", {
 
 export type EdiSettings = typeof ediSettings.$inferSelect;
 export type InsertEdiSettings = typeof ediSettings.$inferInsert;
-export type InvestmentGrantItem = typeof investmentGrantItems.$inferSelect;
-export type InsertInvestmentGrantItem = typeof investmentGrantItems.$inferInsert;
 
 // ============================================
 // FIREFLIES INTEGRATION
@@ -6099,9 +6100,6 @@ export const codeExecutions = mysqlTable("codeExecutions", {
   status: mysqlEnum("status", ["pending", "running", "completed", "failed", "timeout"]).default("pending").notNull(),
   createdAt: timestamp("createdAt").defaultNow().notNull(),
 });
-
-export type InvestmentGrantItem = typeof investmentGrantItems.$inferSelect;
-export type InsertInvestmentGrantItem = typeof investmentGrantItems.$inferInsert;
 
 // ============================================
 // R&D TAX CREDIT (IRC SECTION 41)

--- a/server/db.ts
+++ b/server/db.ts
@@ -10399,7 +10399,6 @@ export async function updateCogsPeriodSummaryRecord(id: number, data: Partial<In
   return { id };
 }
 
-<<<<<<< claude/rd-tax-credit-feature-IEATs
 // ============================================
 // R&D TAX CREDIT OPERATIONS
 // ============================================
@@ -12138,5 +12137,4 @@ export async function updateInvestmentCommitment(id: number, data: Partial<Inser
   const db = await getDb();
   if (!db) throw new Error("Database not available");
   await db.update(investmentCommitments).set({ ...data, updatedAt: new Date() } as any).where(eq(investmentCommitments.id, id));
->>>>>>> main
 }

--- a/server/firefliesSyncService.ts
+++ b/server/firefliesSyncService.ts
@@ -17,8 +17,10 @@ import {
   getTranscript,
   extractParticipants,
   parseActionItems,
+  type FirefliesActionItem,
 } from "./_core/fireflies";
 import * as db from "./db";
+import { invokeLLM } from "./_core/llm";
 
 export interface FirefliesSyncResult {
   totalSynced: number;
@@ -26,7 +28,142 @@ export interface FirefliesSyncResult {
   contactsCreated: number;
   dealsCreated: number;
   notificationsCreated: number;
+  tasksSuggested: number;
   errors: string[];
+}
+
+const ALLOWED_TASK_DOMAINS = new Set(["fundraising", "sales", "legal"]);
+
+function classifyTaskDomain(text: string): "fundraising" | "sales" | "legal" | null {
+  const t = text.toLowerCase();
+  if (/\b(fundrais|investor|pitch|seed|series a|series b|term sheet|cap table|runway|valuation)\b/.test(t)) return "fundraising";
+  if (/\b(sales|lead|prospect|demo|pipeline|quote|proposal|renewal|close|customer)\b/.test(t)) return "sales";
+  if (/\b(legal|contract|nda|msa|dpa|compliance|policy|terms|counsel|regulatory)\b/.test(t)) return "legal";
+  return null;
+}
+
+async function routeTaskProjectAndAssignee(params: {
+  taskText: string;
+  domain: "fundraising" | "sales" | "legal";
+  meetingTitle: string;
+  participants: Array<{ name: string; email: string }>;
+  preferredProjectId?: number;
+  preferredAssigneeHint?: string;
+}) {
+  const projects = await db.getProjects();
+  const teamMembers = await db.getTeamMembers();
+  const projectIndex = new Map((projects || []).map((p: any) => [p.id, p]));
+  const userIndex = new Map((teamMembers || []).map((u: any) => [u.id, u]));
+
+  if (params.preferredProjectId && projectIndex.has(params.preferredProjectId)) {
+    const assigneeId = (teamMembers || []).find((u: any) => {
+      const hint = (params.preferredAssigneeHint || "").toLowerCase();
+      if (!hint) return false;
+      return (u.name || "").toLowerCase().includes(hint) || (u.email || "").toLowerCase().includes(hint);
+    })?.id ?? null;
+    return { projectId: params.preferredProjectId, assigneeId };
+  }
+
+  const domainProject = (projects || []).find((p: any) =>
+    `${p.name || ""} ${p.description || ""}`.toLowerCase().includes(params.domain)
+  );
+  if (domainProject) return { projectId: domainProject.id, assigneeId: null as number | null };
+
+  if (!projects?.length) return { projectId: null as number | null, assigneeId: null as number | null };
+
+  try {
+    const response = await invokeLLM({
+      messages: [
+        { role: "system", content: "Route this action item to a project and optional assignee. Return JSON only: {\"projectId\":number|null,\"assigneeId\":number|null}." },
+        {
+          role: "user",
+          content: JSON.stringify({
+            taskText: params.taskText,
+            domain: params.domain,
+            meetingTitle: params.meetingTitle,
+            participants: params.participants,
+            assigneeHint: params.preferredAssigneeHint || null,
+            projects: (projects || []).map((p: any) => ({ id: p.id, name: p.name, description: p.description })),
+            assignees: (teamMembers || []).map((u: any) => ({ id: u.id, name: u.name, email: u.email })),
+          }),
+        },
+      ],
+    });
+    const text = typeof response.choices?.[0]?.message?.content === "string" ? response.choices[0].message.content : "";
+    const parsed = JSON.parse(text.replace(/```json\n?|\n?```/g, "").trim() || "{}");
+    const projectId = typeof parsed.projectId === "number" && projectIndex.has(parsed.projectId) ? parsed.projectId : null;
+    const assigneeId = typeof parsed.assigneeId === "number" && userIndex.has(parsed.assigneeId) ? parsed.assigneeId : null;
+    return { projectId, assigneeId };
+  } catch {
+    return { projectId: null as number | null, assigneeId: null as number | null };
+  }
+}
+
+export async function queueFirefliesActionItemsForApproval(params: {
+  userId: number;
+  meetingId?: number;
+  meetingTitle: string;
+  firefliesId?: string;
+  actionItems: FirefliesActionItem[];
+  participants: Array<{ name: string; email: string }>;
+  preferredProjectId?: number;
+}): Promise<number> {
+  let created = 0;
+  for (const item of params.actionItems) {
+    const taskText = item.text?.trim();
+    if (!taskText) continue;
+    const domain = classifyTaskDomain(taskText);
+    if (!domain || !ALLOWED_TASK_DOMAINS.has(domain)) continue;
+
+    const routing = await routeTaskProjectAndAssignee({
+      taskText,
+      domain,
+      meetingTitle: params.meetingTitle,
+      participants: params.participants,
+      preferredProjectId: params.preferredProjectId,
+      preferredAssigneeHint: item.assignee,
+    });
+    if (!routing.projectId) continue;
+
+    const taskPayload = {
+      action: "create_project_task",
+      projectId: routing.projectId,
+      name: taskText,
+      description: `From Fireflies meeting: ${params.meetingTitle}`,
+      assigneeId: routing.assigneeId,
+      dueDate: item.dueDate || null,
+      priority: "medium",
+      source: "fireflies",
+      sourceMeeting: {
+        firefliesId: params.firefliesId || null,
+        meetingId: params.meetingId || null,
+        title: params.meetingTitle,
+      },
+      domain,
+    };
+
+    const suggested = await db.createAiAgentTask({
+      taskType: "query" as any,
+      priority: "medium",
+      status: "pending_approval",
+      taskData: JSON.stringify(taskPayload),
+      aiReasoning: `Suggested ${domain} task extracted from Fireflies action item`,
+      aiConfidence: "75.00",
+      relatedEntityType: "project",
+      relatedEntityId: routing.projectId,
+      requiresApproval: true,
+    } as any);
+
+    await db.createAiAgentLog({
+      taskId: suggested.id,
+      action: "fireflies_task_suggested",
+      status: "info",
+      message: `Fireflies task queued for approval: ${taskText.substring(0, 120)}`,
+      details: JSON.stringify(taskPayload),
+    } as any);
+    created++;
+  }
+  return created;
 }
 
 /**
@@ -42,6 +179,7 @@ export async function syncFirefliesMeetingsForUser(
     contactsCreated: 0,
     dealsCreated: 0,
     notificationsCreated: 0,
+    tasksSuggested: 0,
     errors: [],
   };
 
@@ -156,20 +294,14 @@ export async function syncFirefliesMeetingsForUser(
           }
         }
 
-        // Auto-create notifications from action items
-        for (const item of actionItems) {
-          try {
-            await db.createNotification({
-              userId,
-              type: "reminder",
-              title: `Meeting Action Item: ${typeof item === "string" ? item.substring(0, 100) : String(item).substring(0, 100)}`,
-              message: `From meeting: ${fullTranscript?.title || t.title || "Unknown"}`,
-            });
-            result.notificationsCreated++;
-          } catch {
-            /* skip failed notification */
-          }
-        }
+        const suggested = await queueFirefliesActionItemsForApproval({
+          userId,
+          meetingTitle: fullTranscript?.title || t.title || "Unknown meeting",
+          firefliesId: t.id,
+          actionItems: parseActionItems(actionItems),
+          participants,
+        });
+        result.tasksSuggested += suggested;
       } catch (meetingErr) {
         result.errors.push(
           `Failed to sync meeting ${t.id}: ${meetingErr instanceof Error ? meetingErr.message : String(meetingErr)}`
@@ -196,6 +328,7 @@ export async function syncAllFirefliesMeetings(): Promise<FirefliesSyncResult> {
     contactsCreated: 0,
     dealsCreated: 0,
     notificationsCreated: 0,
+    tasksSuggested: 0,
     errors: [],
   };
 
@@ -214,6 +347,7 @@ export async function syncAllFirefliesMeetings(): Promise<FirefliesSyncResult> {
         aggregate.contactsCreated += result.contactsCreated;
         aggregate.dealsCreated += result.dealsCreated;
         aggregate.notificationsCreated += result.notificationsCreated;
+        aggregate.tasksSuggested += result.tasksSuggested;
         aggregate.errors.push(...result.errors);
       } catch (userErr) {
         aggregate.errors.push(

--- a/server/routers.ts
+++ b/server/routers.ts
@@ -39,6 +39,7 @@ import { createGoogleDoc, insertTextInDoc, getGoogleDoc, updateGoogleDoc, create
 import { getGoogleFullAccessAuthUrl, syncDriveFolder, listDriveFolders, getFolderInfo, getSimpleFileType, downloadDriveFile } from "./_core/googleDrive";
 import { getQuickBooksAuthUrl, validateOAuthState, exchangeCodeForToken, refreshQuickBooksToken, getCompanyInfo, getChartOfAccounts, getQuickBooksItems } from "./_core/quickbooks";
 import { listAllTranscripts, getTranscript, extractParticipants, parseActionItems, validateApiKey as validateFirefliesApiKey } from "./_core/fireflies";
+import { queueFirefliesActionItemsForApproval } from "./firefliesSyncService";
 import { processInboundEdi, convertEdi850ToOrder, generateOutboundEdi, getTransactionSetDescription, type Edi855Acknowledgment, type Edi810Invoice, type Edi856ShipNotice } from "./ediService";
 import type { InsertDataRoomDriveSyncConfig } from "../drizzle/schema";
 import { collectERPData, autoPopulateFields, generateApplicationNarrative, reviewApplication, generateApplicationDocument, DEFAULT_SECTIONS, searchOpportunities, evaluateOpportunityFit, analyzeWebFormFields, generateAutoFillScript, generateCopyPasteGuide, generateApiPayload } from "./grantBidService";
@@ -545,8 +546,29 @@ export const appRouter = router({
             .toLowerCase()
             .replace(/[^a-z0-9]+/g, "-")
             .replace(/(^-|-$)/g, "") || "product";
+          const companyPrefixes = [
+            "Shenzhen",
+            "Guangzhou",
+            "Ningbo",
+            "Dongguan",
+            "Wenzhou",
+            "Yiwu",
+            "Qingdao",
+            "Foshan",
+          ];
+          const companyTypes = [
+            "Industrial",
+            "Trading",
+            "Technology",
+            "Manufacturing",
+            "Supply Chain",
+            "Commerce",
+            "Export",
+            "Materials",
+          ];
+          const firstWord = query.split(" ")[0] || "Global";
           return {
-            companyName: `Shenzhen ${query.split(" ")[0] || "Global"} Sourcing Co., Ltd.`,
+            companyName: `${companyPrefixes[i]} ${firstWord} ${companyTypes[i]} Co., Ltd.`,
             productName: `${query} - Model ${String.fromCharCode(65 + i)}`,
             priceRange: `$${priceFloor} - $${priceCeil}`,
             minOrder: `${moq} Pieces`,
@@ -18384,7 +18406,7 @@ Recent interactions: ${(interactions as any[]).slice(0, 5).map((i: any) => `${i.
       let skipped = 0;
       let dealsCreated = 0;
       let contactsCreated = 0;
-      let actionItemNotifications = 0;
+      let tasksSuggested = 0;
       for (const t of transcripts) {
         const existing = await db.getFirefliesMeetingByFirefliesId(t.id);
         if (existing) {
@@ -18472,23 +18494,19 @@ Recent interactions: ${(interactions as any[]).slice(0, 5).map((i: any) => `${i.
             }
           }
 
-          // Auto-create notifications from action items
-          for (const item of actionItems) {
-            try {
-              await db.createNotification({
-                userId: ctx.user.id,
-                type: "reminder",
-                title: `Meeting Action Item: ${typeof item === "string" ? item.substring(0, 100) : String(item).substring(0, 100)}`,
-                message: `From meeting: ${fullTranscript?.title || t.title || "Unknown"}`,
-              });
-              actionItemNotifications++;
-            } catch { /* skip failed notification */ }
-          }
+          const suggested = await queueFirefliesActionItemsForApproval({
+            userId: ctx.user.id,
+            meetingTitle: fullTranscript?.title || t.title || "Unknown meeting",
+            firefliesId: t.id,
+            actionItems: parseActionItems(actionItems),
+            participants,
+          });
+          tasksSuggested += suggested;
         } catch (e) {
           console.warn("[CRM Auto-Deal] Failed to create deal from meeting:", e);
         }
       }
-      return { synced, skipped, dealsCreated, contactsCreated, actionItemNotifications };
+      return { synced, skipped, dealsCreated, contactsCreated, tasksSuggested };
     }),
     processMeeting: protectedProcedure
       .input(z.object({
@@ -18538,18 +18556,19 @@ Recent interactions: ${(interactions as any[]).slice(0, 5).map((i: any) => `${i.
           projectId = project.id;
         }
 
-        // Create tasks from action items
+        // Queue tasks from action items for approval
         if (input.createTasks && meeting.actionItems) {
-          for (const item of (meeting.actionItems ? JSON.parse(meeting.actionItems) : []) as Array<{ text: string }>) {
-            if (projectId) {
-              await db.createProjectTask({
-                projectId,
-                name: item.text,
-                status: 'todo',
-              } as any);
-              tasksCreated++;
-            }
-          }
+          const parsedParticipants: Array<{ name: string; email: string }> =
+            typeof meeting.participants === 'string' ? JSON.parse(meeting.participants) :
+            Array.isArray(meeting.participants) ? meeting.participants : [];
+          tasksCreated += await queueFirefliesActionItemsForApproval({
+            userId: ctx.user.id,
+            meetingId: meeting.id,
+            meetingTitle: meeting.title || 'Untitled meeting',
+            actionItems: (meeting.actionItems ? JSON.parse(meeting.actionItems) : []) as Array<{ text: string; assignee?: string; dueDate?: string }>,
+            participants: parsedParticipants,
+            preferredProjectId: projectId,
+          });
         }
 
         const status: 'fully_processed' | 'contacts_created' | 'tasks_created' | 'pending' =
@@ -18618,16 +18637,17 @@ Recent interactions: ${(interactions as any[]).slice(0, 5).map((i: any) => `${i.
             projectId = project.id;
             projectsCreated++;
           }
-          for (const item of items) {
-            if (projectId) {
-              await db.createProjectTask({
-                projectId,
-                name: item.text,
-                status: 'todo',
-              } as any);
-              tasksCreated++;
-            }
-          }
+          const parsedParticipants: Array<{ name: string; email: string }> =
+            typeof meeting.participants === 'string' ? JSON.parse(meeting.participants) :
+            Array.isArray(meeting.participants) ? meeting.participants : [];
+          tasksCreated += await queueFirefliesActionItemsForApproval({
+            userId: ctx.user.id,
+            meetingId: meeting.id,
+            meetingTitle: meeting.title || 'Untitled meeting',
+            actionItems: items as Array<{ text: string; assignee?: string; dueDate?: string }>,
+            participants: parsedParticipants,
+            preferredProjectId: projectId,
+          });
         }
         await db.updateFirefliesMeeting(meeting.id, { processingStatus: 'fully_processed' });
         processed++;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Routes Fireflies meeting action items into an approval queue with domain-aware project/assignee suggestions. Also polishes Meetings/Projects UI and fixes schema/router issues.

- **New Features**
  - Converts Fireflies action items into task suggestions that require approval.
  - Classifies items as fundraising, sales, or legal, and suggests a project/assignee.
  - Sync and router endpoints now use this queue and report `tasksSuggested`.

- **Bug Fixes**
  - UI: neutralized Projects badges and overdue styling; updated icons (e.g., "In Review"); removed extra folder icon; Meetings filter reset now also clears list view; smaller ComponentShowcase title; added `Bot`, `Heart`, `Building2` icons in the sidebar; supplier search generates varied company names.
  - Backend: ApprovalQueue loads team via `trpc.team.list`; fixed `drizzle-orm` self-reference typing for `accounts.parentAccountId`; deduped `InvestmentGrantItem` type exports; removed merge conflict markers.

<sup>Written for commit e9d31c1887ef87d71b7c6d85c430e06b21a6bbd2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

