### PR TITLE
Add employee self-service portal for HR management

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -97,6 +97,7 @@ const CustomsDetail = lazy(() => import("./pages/freight/CustomsDetail"));
 // HR
 const HRHub = lazy(() => import("./pages/hr/HRHub"));
 const Employees = lazy(() => import("./pages/hr/Employees"));
+const EmployeePortal = lazy(() => import("./pages/hr/EmployeePortal"));
 const Payroll = lazy(() => import("./pages/hr/Payroll"));
 const EquityPortal = lazy(() => import("./pages/hr/EquityPortal"));
 const EquityReports = lazy(() => import("./pages/hr/EquityReports"));
@@ -303,6 +304,7 @@ function Router() {
 
           {/* HR */}
           <Route path="/hr" component={HRHub} />
+          <Route path="/hr/me" component={EmployeePortal} />
           <Route path="/hr/investors" component={InvestorsHub} />
           <Route path="/hr/employees" component={Employees} />
           <Route path="/hr/payroll" component={Payroll} />

--- a/client/src/pages/hr/EmployeePortal.tsx
+++ b/client/src/pages/hr/EmployeePortal.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import { trpc } from "@/lib/trpc";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -311,6 +311,17 @@ function ProfileTab({ me, onSaved }: { me: any; onSaved: () => void }) {
   const [state, setState] = useState(me.state || "");
   const [country, setCountry] = useState(me.country || "");
   const [postalCode, setPostalCode] = useState(me.postalCode || "");
+
+  // Sync form fields when 'me' data changes (e.g. after save or external update)
+  useEffect(() => {
+    setPhone(me.phone || "");
+    setPersonalEmail(me.personalEmail || "");
+    setAddress(me.address || "");
+    setCity(me.city || "");
+    setState(me.state || "");
+    setCountry(me.country || "");
+    setPostalCode(me.postalCode || "");
+  }, [me]);
 
   const update = trpc.employeePortal.updateProfile.useMutation({
     onSuccess: () => {
@@ -1160,6 +1171,7 @@ function EmergencyContactsTab({
                 <Button
                   size="sm"
                   variant="ghost"
+                  aria-label="Delete emergency contact"
                   onClick={() => remove.mutate({ id: c.id })}
                 >
                   <Trash2 className="h-4 w-4" />

--- a/client/src/pages/hr/EmployeePortal.tsx
+++ b/client/src/pages/hr/EmployeePortal.tsx
@@ -566,8 +566,8 @@ function TimeOffTab({
     }
     submit.mutate({
       leaveType,
-      startDate: new Date(startDate),
-      endDate: new Date(endDate),
+      startDate: new Date(startDate + "T00:00:00"),
+      endDate: new Date(endDate + "T00:00:00"),
       hours: hrs,
       reason: reason || undefined,
     });

--- a/client/src/pages/hr/EmployeePortal.tsx
+++ b/client/src/pages/hr/EmployeePortal.tsx
@@ -1,0 +1,1174 @@
+import { useState, useMemo } from "react";
+import { trpc } from "@/lib/trpc";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import { Textarea } from "@/components/ui/textarea";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  User,
+  DollarSign,
+  Calendar,
+  ClipboardList,
+  Shield,
+  FileText,
+  Users,
+  CheckCircle2,
+  Clock,
+  Plus,
+  Trash2,
+  Circle,
+} from "lucide-react";
+import { toast } from "sonner";
+
+const LEAVE_TYPES = [
+  "vacation",
+  "sick",
+  "personal",
+  "parental",
+  "bereavement",
+  "unpaid",
+  "other",
+] as const;
+
+const BENEFIT_TYPES = [
+  "health",
+  "dental",
+  "vision",
+  "retirement_401k",
+  "life_insurance",
+  "disability",
+  "hsa",
+  "fsa",
+  "commuter",
+  "other",
+] as const;
+
+type LeaveType = (typeof LEAVE_TYPES)[number];
+type BenefitType = (typeof BENEFIT_TYPES)[number];
+
+const STATUS_COLORS: Record<string, string> = {
+  pending: "bg-yellow-100 text-yellow-800",
+  approved: "bg-green-100 text-green-800",
+  rejected: "bg-red-100 text-red-800",
+  cancelled: "bg-gray-100 text-gray-700",
+  completed: "bg-green-100 text-green-800",
+  in_progress: "bg-blue-100 text-blue-800",
+  skipped: "bg-gray-100 text-gray-700",
+  enrolled: "bg-green-100 text-green-800",
+  waived: "bg-gray-100 text-gray-700",
+  terminated: "bg-red-100 text-red-800",
+  processed: "bg-green-100 text-green-800",
+};
+
+function formatCurrency(value: string | number | null | undefined) {
+  const num = parseFloat(String(value || "0"));
+  return new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(num);
+}
+
+function formatDate(date: string | Date | null | undefined) {
+  if (!date) return "-";
+  return new Date(date).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function titleCase(s: string) {
+  return s
+    .split("_")
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}
+
+export default function EmployeePortal() {
+  const utils = trpc.useUtils();
+
+  const { data: me, isLoading: meLoading } = trpc.employeePortal.me.useQuery();
+  const { data: payslips } = trpc.employeePortal.payslips.useQuery();
+  const { data: ptoBalances } = trpc.employeePortal.ptoBalances.useQuery();
+  const { data: leaveRequests } = trpc.employeePortal.leaveRequests.useQuery();
+  const { data: onboardingTasks } = trpc.employeePortal.onboardingTasks.useQuery();
+  const { data: benefits } = trpc.employeePortal.benefits.useQuery();
+  const { data: documents } = trpc.employeePortal.documents.useQuery();
+  const { data: directory } = trpc.employeePortal.directory.useQuery();
+  const { data: emergencyContacts } = trpc.employeePortal.emergencyContacts.useQuery();
+  const { data: compensation } = trpc.employeePortal.compensation.useQuery();
+
+  if (meLoading) {
+    return (
+      <div className="p-6 text-muted-foreground">Loading your portal…</div>
+    );
+  }
+
+  if (!me) {
+    return (
+      <div className="p-6">
+        <Card>
+          <CardContent className="pt-6">
+            <p className="text-muted-foreground">
+              No employee record is linked to your user account. Please contact HR to get set up.
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  const totalAccrued = (ptoBalances || []).reduce(
+    (sum, b) => sum + parseFloat(String(b.accruedHours || "0")),
+    0,
+  );
+  const totalUsed = (ptoBalances || []).reduce(
+    (sum, b) => sum + parseFloat(String(b.usedHours || "0")),
+    0,
+  );
+  const totalPending = (ptoBalances || []).reduce(
+    (sum, b) => sum + parseFloat(String(b.pendingHours || "0")),
+    0,
+  );
+  const availableHours = totalAccrued - totalUsed - totalPending;
+
+  const openTasks = (onboardingTasks || []).filter((t) => t.status !== "completed" && t.status !== "skipped").length;
+  const completedTasks = (onboardingTasks || []).filter((t) => t.status === "completed").length;
+
+  return (
+    <div className="space-y-6 p-6">
+      <div className="flex items-center gap-3">
+        <User className="h-7 w-7 text-primary" />
+        <div>
+          <h1 className="text-2xl font-bold">
+            Welcome, {me.firstName}
+          </h1>
+          <p className="text-muted-foreground">
+            {me.jobTitle || "Employee"} · Employee #{me.employeeNumber || "—"}
+          </p>
+        </div>
+      </div>
+
+      {/* Summary cards */}
+      <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium flex items-center gap-2">
+              <Calendar className="h-4 w-4" />
+              PTO Available
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{availableHours.toFixed(1)}h</div>
+            <p className="text-xs text-muted-foreground">
+              {totalPending.toFixed(1)}h pending · {totalUsed.toFixed(1)}h used
+            </p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium flex items-center gap-2">
+              <DollarSign className="h-4 w-4" />
+              Last Payslip
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">
+              {payslips && payslips[0]
+                ? formatCurrency(payslips[0].amount)
+                : "—"}
+            </div>
+            <p className="text-xs text-muted-foreground">
+              {payslips && payslips[0] ? formatDate(payslips[0].paymentDate) : "No pay history"}
+            </p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium flex items-center gap-2">
+              <ClipboardList className="h-4 w-4" />
+              Onboarding
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">
+              {completedTasks}/{(onboardingTasks || []).length}
+            </div>
+            <p className="text-xs text-muted-foreground">{openTasks} open task(s)</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium flex items-center gap-2">
+              <Shield className="h-4 w-4" />
+              Benefits Enrolled
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">
+              {(benefits || []).filter((b) => b.enrollmentStatus === "enrolled").length}
+            </div>
+            <p className="text-xs text-muted-foreground">
+              of {(benefits || []).length} elections
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Tabs defaultValue="profile" className="w-full">
+        <TabsList className="grid w-full grid-cols-4 lg:grid-cols-8">
+          <TabsTrigger value="profile">Profile</TabsTrigger>
+          <TabsTrigger value="pay">Pay</TabsTrigger>
+          <TabsTrigger value="timeoff">Time Off</TabsTrigger>
+          <TabsTrigger value="onboarding">Onboarding</TabsTrigger>
+          <TabsTrigger value="benefits">Benefits</TabsTrigger>
+          <TabsTrigger value="documents">Documents</TabsTrigger>
+          <TabsTrigger value="directory">Directory</TabsTrigger>
+          <TabsTrigger value="emergency">Emergency</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="profile" className="mt-4">
+          <ProfileTab me={me} onSaved={() => utils.employeePortal.me.invalidate()} />
+        </TabsContent>
+
+        <TabsContent value="pay" className="mt-4">
+          <PayTab payslips={payslips || []} compensation={compensation || []} />
+        </TabsContent>
+
+        <TabsContent value="timeoff" className="mt-4">
+          <TimeOffTab
+            balances={ptoBalances || []}
+            requests={leaveRequests || []}
+            onChange={() => {
+              utils.employeePortal.leaveRequests.invalidate();
+              utils.employeePortal.ptoBalances.invalidate();
+            }}
+          />
+        </TabsContent>
+
+        <TabsContent value="onboarding" className="mt-4">
+          <OnboardingTab
+            tasks={onboardingTasks || []}
+            onChange={() => utils.employeePortal.onboardingTasks.invalidate()}
+          />
+        </TabsContent>
+
+        <TabsContent value="benefits" className="mt-4">
+          <BenefitsTab
+            benefits={benefits || []}
+            onChange={() => utils.employeePortal.benefits.invalidate()}
+          />
+        </TabsContent>
+
+        <TabsContent value="documents" className="mt-4">
+          <DocumentsTab documents={documents || []} />
+        </TabsContent>
+
+        <TabsContent value="directory" className="mt-4">
+          <DirectoryTab directory={directory || []} />
+        </TabsContent>
+
+        <TabsContent value="emergency" className="mt-4">
+          <EmergencyContactsTab
+            contacts={emergencyContacts || []}
+            onChange={() => utils.employeePortal.emergencyContacts.invalidate()}
+          />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}
+
+// ==================== Profile ====================
+function ProfileTab({ me, onSaved }: { me: any; onSaved: () => void }) {
+  const [phone, setPhone] = useState(me.phone || "");
+  const [personalEmail, setPersonalEmail] = useState(me.personalEmail || "");
+  const [address, setAddress] = useState(me.address || "");
+  const [city, setCity] = useState(me.city || "");
+  const [state, setState] = useState(me.state || "");
+  const [country, setCountry] = useState(me.country || "");
+  const [postalCode, setPostalCode] = useState(me.postalCode || "");
+
+  const update = trpc.employeePortal.updateProfile.useMutation({
+    onSuccess: () => {
+      toast.success("Profile updated");
+      onSaved();
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>My Profile</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <Label>Legal name</Label>
+            <Input value={`${me.firstName} ${me.lastName}`} disabled />
+          </div>
+          <div>
+            <Label>Work email</Label>
+            <Input value={me.email || ""} disabled />
+          </div>
+          <div>
+            <Label>Job title</Label>
+            <Input value={me.jobTitle || ""} disabled />
+          </div>
+          <div>
+            <Label>Hire date</Label>
+            <Input value={formatDate(me.hireDate)} disabled />
+          </div>
+        </div>
+        <div className="border-t pt-4 space-y-4">
+          <div className="text-sm text-muted-foreground">
+            Contact info you can edit yourself. For anything else (name, title,
+            bank, tax ID), contact HR.
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <Label>Phone</Label>
+              <Input value={phone} onChange={(e) => setPhone(e.target.value)} />
+            </div>
+            <div>
+              <Label>Personal email</Label>
+              <Input value={personalEmail} onChange={(e) => setPersonalEmail(e.target.value)} />
+            </div>
+            <div className="md:col-span-2">
+              <Label>Address</Label>
+              <Input value={address} onChange={(e) => setAddress(e.target.value)} />
+            </div>
+            <div>
+              <Label>City</Label>
+              <Input value={city} onChange={(e) => setCity(e.target.value)} />
+            </div>
+            <div>
+              <Label>State / Region</Label>
+              <Input value={state} onChange={(e) => setState(e.target.value)} />
+            </div>
+            <div>
+              <Label>Country</Label>
+              <Input value={country} onChange={(e) => setCountry(e.target.value)} />
+            </div>
+            <div>
+              <Label>Postal code</Label>
+              <Input value={postalCode} onChange={(e) => setPostalCode(e.target.value)} />
+            </div>
+          </div>
+          <Button
+            onClick={() =>
+              update.mutate({
+                phone,
+                personalEmail,
+                address,
+                city,
+                state,
+                country,
+                postalCode,
+              })
+            }
+            disabled={update.isPending}
+          >
+            Save changes
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ==================== Pay ====================
+function PayTab({ payslips, compensation }: { payslips: any[]; compensation: any[] }) {
+  const ytd = useMemo(() => {
+    const year = new Date().getFullYear();
+    return payslips
+      .filter((p) => new Date(p.paymentDate).getFullYear() === year && p.status === "processed")
+      .reduce((sum, p) => sum + parseFloat(String(p.amount || "0")), 0);
+  }, [payslips]);
+
+  const currentComp = compensation[0];
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm">YTD Earnings</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{formatCurrency(ytd)}</div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm">Current Compensation</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">
+              {currentComp ? formatCurrency(currentComp.salary) : "—"}
+            </div>
+            <p className="text-xs text-muted-foreground">
+              {currentComp?.salaryFrequency
+                ? titleCase(currentComp.salaryFrequency)
+                : "Not on record"}
+            </p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm">Payslips</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{payslips.length}</div>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Pay History</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {payslips.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No payslips yet.</p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Pay date</TableHead>
+                  <TableHead>Period</TableHead>
+                  <TableHead>Type</TableHead>
+                  <TableHead className="text-right">Gross</TableHead>
+                  <TableHead className="text-right">Tax</TableHead>
+                  <TableHead className="text-right">Net</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Slip</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {payslips.map((p) => (
+                  <TableRow key={p.id}>
+                    <TableCell>{formatDate(p.paymentDate)}</TableCell>
+                    <TableCell className="text-xs">
+                      {p.payPeriodStart ? formatDate(p.payPeriodStart) : "—"}
+                      {" — "}
+                      {p.payPeriodEnd ? formatDate(p.payPeriodEnd) : "—"}
+                    </TableCell>
+                    <TableCell>{titleCase(p.type || "salary")}</TableCell>
+                    <TableCell className="text-right">
+                      {p.grossAmount ? formatCurrency(p.grossAmount) : "—"}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      {p.taxWithheld ? formatCurrency(p.taxWithheld) : "—"}
+                    </TableCell>
+                    <TableCell className="text-right font-medium">
+                      {formatCurrency(p.amount)}
+                    </TableCell>
+                    <TableCell>
+                      <Badge className={STATUS_COLORS[p.status] || ""}>{p.status}</Badge>
+                    </TableCell>
+                    <TableCell>
+                      {p.payslipUrl ? (
+                        <a
+                          href={p.payslipUrl}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="text-primary underline text-sm"
+                        >
+                          Download
+                        </a>
+                      ) : (
+                        <span className="text-xs text-muted-foreground">—</span>
+                      )}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+// ==================== Time Off ====================
+function TimeOffTab({
+  balances,
+  requests,
+  onChange,
+}: {
+  balances: any[];
+  requests: any[];
+  onChange: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [leaveType, setLeaveType] = useState<LeaveType>("vacation");
+  const [startDate, setStartDate] = useState("");
+  const [endDate, setEndDate] = useState("");
+  const [hours, setHours] = useState("8");
+  const [reason, setReason] = useState("");
+
+  const submit = trpc.employeePortal.submitLeaveRequest.useMutation({
+    onSuccess: () => {
+      toast.success("Leave request submitted");
+      setOpen(false);
+      setStartDate("");
+      setEndDate("");
+      setHours("8");
+      setReason("");
+      onChange();
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  const cancel = trpc.employeePortal.cancelLeaveRequest.useMutation({
+    onSuccess: () => {
+      toast.success("Request cancelled");
+      onChange();
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  const handleSubmit = () => {
+    if (!startDate || !endDate) {
+      toast.error("Select start and end dates");
+      return;
+    }
+    const hrs = parseFloat(hours);
+    if (!hrs || hrs <= 0) {
+      toast.error("Hours must be greater than 0");
+      return;
+    }
+    submit.mutate({
+      leaveType,
+      startDate: new Date(startDate),
+      endDate: new Date(endDate),
+      hours: hrs,
+      reason: reason || undefined,
+    });
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+        {balances.length === 0 ? (
+          <Card className="md:col-span-4">
+            <CardContent className="pt-6 text-sm text-muted-foreground">
+              No PTO balances on file yet. HR will set them up.
+            </CardContent>
+          </Card>
+        ) : (
+          balances.map((b) => {
+            const accrued = parseFloat(String(b.accruedHours || "0"));
+            const used = parseFloat(String(b.usedHours || "0"));
+            const pending = parseFloat(String(b.pendingHours || "0"));
+            const available = accrued - used - pending;
+            return (
+              <Card key={b.id}>
+                <CardHeader className="pb-2">
+                  <CardTitle className="text-sm">{titleCase(b.leaveType)}</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <div className="text-2xl font-bold">{available.toFixed(1)}h</div>
+                  <p className="text-xs text-muted-foreground">
+                    {accrued.toFixed(1)}h accrued · {used.toFixed(1)}h used · {pending.toFixed(1)}h pending
+                  </p>
+                </CardContent>
+              </Card>
+            );
+          })
+        )}
+      </div>
+
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between">
+          <CardTitle>My Leave Requests</CardTitle>
+          <Dialog open={open} onOpenChange={setOpen}>
+            <Button onClick={() => setOpen(true)}>
+              <Plus className="h-4 w-4 mr-2" /> Request time off
+            </Button>
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>Request time off</DialogTitle>
+                <DialogDescription>
+                  Your manager will review and approve this request.
+                </DialogDescription>
+              </DialogHeader>
+              <div className="space-y-4">
+                <div>
+                  <Label>Leave type</Label>
+                  <Select value={leaveType} onValueChange={(v) => setLeaveType(v as LeaveType)}>
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {LEAVE_TYPES.map((t) => (
+                        <SelectItem key={t} value={t}>
+                          {titleCase(t)}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="grid grid-cols-2 gap-4">
+                  <div>
+                    <Label>Start date</Label>
+                    <Input
+                      type="date"
+                      value={startDate}
+                      onChange={(e) => setStartDate(e.target.value)}
+                    />
+                  </div>
+                  <div>
+                    <Label>End date</Label>
+                    <Input
+                      type="date"
+                      value={endDate}
+                      onChange={(e) => setEndDate(e.target.value)}
+                    />
+                  </div>
+                </div>
+                <div>
+                  <Label>Hours</Label>
+                  <Input
+                    type="number"
+                    step="0.5"
+                    value={hours}
+                    onChange={(e) => setHours(e.target.value)}
+                  />
+                </div>
+                <div>
+                  <Label>Reason (optional)</Label>
+                  <Textarea value={reason} onChange={(e) => setReason(e.target.value)} />
+                </div>
+              </div>
+              <DialogFooter>
+                <Button variant="outline" onClick={() => setOpen(false)}>
+                  Cancel
+                </Button>
+                <Button onClick={handleSubmit} disabled={submit.isPending}>
+                  Submit
+                </Button>
+              </DialogFooter>
+            </DialogContent>
+          </Dialog>
+        </CardHeader>
+        <CardContent>
+          {requests.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No requests yet.</p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Type</TableHead>
+                  <TableHead>Dates</TableHead>
+                  <TableHead className="text-right">Hours</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Reason</TableHead>
+                  <TableHead />
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {requests.map((r) => (
+                  <TableRow key={r.id}>
+                    <TableCell>{titleCase(r.leaveType)}</TableCell>
+                    <TableCell className="text-sm">
+                      {formatDate(r.startDate)} — {formatDate(r.endDate)}
+                    </TableCell>
+                    <TableCell className="text-right">{r.hours}</TableCell>
+                    <TableCell>
+                      <Badge className={STATUS_COLORS[r.status] || ""}>{r.status}</Badge>
+                    </TableCell>
+                    <TableCell className="text-sm text-muted-foreground max-w-xs truncate">
+                      {r.reason || "—"}
+                    </TableCell>
+                    <TableCell>
+                      {(r.status === "pending" || r.status === "approved") && (
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          onClick={() => cancel.mutate({ id: r.id })}
+                          disabled={cancel.isPending}
+                        >
+                          Cancel
+                        </Button>
+                      )}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+// ==================== Onboarding ====================
+function OnboardingTab({ tasks, onChange }: { tasks: any[]; onChange: () => void }) {
+  const update = trpc.employeePortal.updateOnboardingTask.useMutation({
+    onSuccess: () => onChange(),
+    onError: (err) => toast.error(err.message),
+  });
+
+  if (tasks.length === 0) {
+    return (
+      <Card>
+        <CardContent className="pt-6 text-sm text-muted-foreground">
+          No onboarding tasks. You're all set!
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const byCategory = tasks.reduce<Record<string, any[]>>((acc, t) => {
+    const key = t.category || "other";
+    (acc[key] = acc[key] || []).push(t);
+    return acc;
+  }, {});
+
+  return (
+    <div className="space-y-4">
+      {Object.entries(byCategory).map(([cat, items]) => (
+        <Card key={cat}>
+          <CardHeader>
+            <CardTitle>{titleCase(cat)}</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            {items.map((t) => {
+              const done = t.status === "completed";
+              return (
+                <div
+                  key={t.id}
+                  className="flex items-start gap-3 border rounded p-3 hover:bg-muted/40"
+                >
+                  <button
+                    onClick={() =>
+                      update.mutate({
+                        id: t.id,
+                        status: done ? "pending" : "completed",
+                      })
+                    }
+                    className="mt-0.5"
+                  >
+                    {done ? (
+                      <CheckCircle2 className="h-5 w-5 text-green-600" />
+                    ) : (
+                      <Circle className="h-5 w-5 text-muted-foreground" />
+                    )}
+                  </button>
+                  <div className="flex-1">
+                    <div className={`font-medium ${done ? "line-through text-muted-foreground" : ""}`}>
+                      {t.title}
+                    </div>
+                    {t.description && (
+                      <div className="text-sm text-muted-foreground">{t.description}</div>
+                    )}
+                    {t.dueDate && (
+                      <div className="text-xs text-muted-foreground mt-1 flex items-center gap-1">
+                        <Clock className="h-3 w-3" /> Due {formatDate(t.dueDate)}
+                      </div>
+                    )}
+                  </div>
+                  <Badge className={STATUS_COLORS[t.status] || ""}>{titleCase(t.status)}</Badge>
+                </div>
+              );
+            })}
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}
+
+// ==================== Benefits ====================
+function BenefitsTab({ benefits, onChange }: { benefits: any[]; onChange: () => void }) {
+  const [open, setOpen] = useState(false);
+  const [benefitType, setBenefitType] = useState<BenefitType>("health");
+  const [plan, setPlan] = useState("");
+  const [carrier, setCarrier] = useState("");
+  const [coverageLevel, setCoverageLevel] = useState("employee_only");
+  const [employeeContribution, setEmployeeContribution] = useState("");
+
+  const upsert = trpc.employeePortal.upsertBenefitElection.useMutation({
+    onSuccess: () => {
+      toast.success("Election saved");
+      setOpen(false);
+      onChange();
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between">
+        <CardTitle>Benefits</CardTitle>
+        <Dialog open={open} onOpenChange={setOpen}>
+          <Button onClick={() => setOpen(true)}>
+            <Plus className="h-4 w-4 mr-2" /> New election
+          </Button>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Benefit election</DialogTitle>
+            </DialogHeader>
+            <div className="space-y-4">
+              <div>
+                <Label>Benefit type</Label>
+                <Select value={benefitType} onValueChange={(v) => setBenefitType(v as BenefitType)}>
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {BENEFIT_TYPES.map((t) => (
+                      <SelectItem key={t} value={t}>
+                        {titleCase(t)}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div>
+                <Label>Plan</Label>
+                <Input value={plan} onChange={(e) => setPlan(e.target.value)} />
+              </div>
+              <div>
+                <Label>Carrier</Label>
+                <Input value={carrier} onChange={(e) => setCarrier(e.target.value)} />
+              </div>
+              <div>
+                <Label>Coverage level</Label>
+                <Select value={coverageLevel} onValueChange={setCoverageLevel}>
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="employee_only">Employee only</SelectItem>
+                    <SelectItem value="employee_spouse">Employee + spouse</SelectItem>
+                    <SelectItem value="employee_children">Employee + children</SelectItem>
+                    <SelectItem value="family">Family</SelectItem>
+                    <SelectItem value="waived">Waived</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div>
+                <Label>Your contribution (per paycheck)</Label>
+                <Input
+                  type="number"
+                  step="0.01"
+                  value={employeeContribution}
+                  onChange={(e) => setEmployeeContribution(e.target.value)}
+                />
+              </div>
+            </div>
+            <DialogFooter>
+              <Button variant="outline" onClick={() => setOpen(false)}>
+                Cancel
+              </Button>
+              <Button
+                onClick={() =>
+                  upsert.mutate({
+                    benefitType,
+                    plan: plan || undefined,
+                    carrier: carrier || undefined,
+                    coverageLevel: coverageLevel as any,
+                    employeeContribution: employeeContribution || undefined,
+                    enrollmentStatus: coverageLevel === "waived" ? "waived" : "pending",
+                  })
+                }
+                disabled={upsert.isPending}
+              >
+                Save
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </CardHeader>
+      <CardContent>
+        {benefits.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No benefit elections yet.</p>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Type</TableHead>
+                <TableHead>Plan</TableHead>
+                <TableHead>Carrier</TableHead>
+                <TableHead>Coverage</TableHead>
+                <TableHead className="text-right">Your cost</TableHead>
+                <TableHead>Status</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {benefits.map((b) => (
+                <TableRow key={b.id}>
+                  <TableCell className="font-medium">{titleCase(b.benefitType)}</TableCell>
+                  <TableCell>{b.plan || "—"}</TableCell>
+                  <TableCell>{b.carrier || "—"}</TableCell>
+                  <TableCell>{b.coverageLevel ? titleCase(b.coverageLevel) : "—"}</TableCell>
+                  <TableCell className="text-right">
+                    {b.employeeContribution ? formatCurrency(b.employeeContribution) : "—"}
+                  </TableCell>
+                  <TableCell>
+                    <Badge className={STATUS_COLORS[b.enrollmentStatus] || ""}>
+                      {b.enrollmentStatus}
+                    </Badge>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+// ==================== Documents ====================
+function DocumentsTab({ documents }: { documents: any[] }) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>My Documents</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {documents.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No documents shared with you. Contracts, policies, and tax forms will appear here.
+          </p>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Name</TableHead>
+                <TableHead>Type</TableHead>
+                <TableHead>Uploaded</TableHead>
+                <TableHead />
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {documents.map((d) => (
+                <TableRow key={d.id}>
+                  <TableCell className="flex items-center gap-2">
+                    <FileText className="h-4 w-4 text-muted-foreground" />
+                    {d.name}
+                  </TableCell>
+                  <TableCell>{titleCase(d.type)}</TableCell>
+                  <TableCell>{formatDate(d.createdAt)}</TableCell>
+                  <TableCell>
+                    <a
+                      href={d.fileUrl}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="text-primary underline text-sm"
+                    >
+                      Open
+                    </a>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+// ==================== Directory ====================
+function DirectoryTab({ directory }: { directory: any[] }) {
+  const [query, setQuery] = useState("");
+  const filtered = directory.filter((p) =>
+    `${p.firstName} ${p.lastName} ${p.jobTitle || ""}`.toLowerCase().includes(query.toLowerCase()),
+  );
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Users className="h-5 w-5" /> Team Directory
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Input
+          placeholder="Search by name or title…"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          className="mb-4"
+        />
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+          {filtered.map((p) => (
+            <div key={p.id} className="border rounded p-3">
+              <div className="font-medium">
+                {p.firstName} {p.lastName}
+              </div>
+              <div className="text-sm text-muted-foreground">{p.jobTitle || "—"}</div>
+              {p.email && <div className="text-xs mt-1">{p.email}</div>}
+            </div>
+          ))}
+          {filtered.length === 0 && (
+            <p className="text-sm text-muted-foreground">No matches.</p>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ==================== Emergency Contacts ====================
+function EmergencyContactsTab({
+  contacts,
+  onChange,
+}: {
+  contacts: any[];
+  onChange: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState("");
+  const [relationship, setRelationship] = useState("");
+  const [phone, setPhone] = useState("");
+  const [email, setEmail] = useState("");
+  const [isPrimary, setIsPrimary] = useState(false);
+
+  const add = trpc.employeePortal.addEmergencyContact.useMutation({
+    onSuccess: () => {
+      toast.success("Contact added");
+      setOpen(false);
+      setName("");
+      setRelationship("");
+      setPhone("");
+      setEmail("");
+      setIsPrimary(false);
+      onChange();
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  const remove = trpc.employeePortal.deleteEmergencyContact.useMutation({
+    onSuccess: () => {
+      toast.success("Contact removed");
+      onChange();
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between">
+        <CardTitle>Emergency Contacts</CardTitle>
+        <Dialog open={open} onOpenChange={setOpen}>
+          <Button onClick={() => setOpen(true)}>
+            <Plus className="h-4 w-4 mr-2" /> Add contact
+          </Button>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Add emergency contact</DialogTitle>
+            </DialogHeader>
+            <div className="space-y-3">
+              <div>
+                <Label>Name</Label>
+                <Input value={name} onChange={(e) => setName(e.target.value)} />
+              </div>
+              <div>
+                <Label>Relationship</Label>
+                <Input value={relationship} onChange={(e) => setRelationship(e.target.value)} />
+              </div>
+              <div>
+                <Label>Phone</Label>
+                <Input value={phone} onChange={(e) => setPhone(e.target.value)} />
+              </div>
+              <div>
+                <Label>Email</Label>
+                <Input value={email} onChange={(e) => setEmail(e.target.value)} />
+              </div>
+              <label className="flex items-center gap-2 text-sm">
+                <input
+                  type="checkbox"
+                  checked={isPrimary}
+                  onChange={(e) => setIsPrimary(e.target.checked)}
+                />
+                Primary contact
+              </label>
+            </div>
+            <DialogFooter>
+              <Button variant="outline" onClick={() => setOpen(false)}>
+                Cancel
+              </Button>
+              <Button
+                onClick={() =>
+                  add.mutate({
+                    name,
+                    relationship: relationship || undefined,
+                    phone: phone || undefined,
+                    email: email || undefined,
+                    isPrimary,
+                  })
+                }
+                disabled={add.isPending || !name.trim()}
+              >
+                Save
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </CardHeader>
+      <CardContent>
+        {contacts.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No emergency contacts on file.</p>
+        ) : (
+          <div className="space-y-2">
+            {contacts.map((c) => (
+              <div key={c.id} className="flex items-start justify-between border rounded p-3">
+                <div>
+                  <div className="font-medium flex items-center gap-2">
+                    {c.name}
+                    {c.isPrimary && <Badge>Primary</Badge>}
+                  </div>
+                  <div className="text-sm text-muted-foreground">
+                    {c.relationship || "—"}
+                  </div>
+                  <div className="text-xs mt-1">
+                    {c.phone && <span className="mr-2">{c.phone}</span>}
+                    {c.email && <span>{c.email}</span>}
+                  </div>
+                </div>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => remove.mutate({ id: c.id })}
+                >
+                  <Trash2 className="h-4 w-4" />
+                </Button>
+              </div>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/client/src/pages/hr/Employees.tsx
+++ b/client/src/pages/hr/Employees.tsx
@@ -517,6 +517,9 @@ export default function PeopleAndEquity() {
           </p>
         </div>
         <div className="flex items-center gap-2">
+          <Button variant="outline" onClick={() => window.location.href = "/hr/me"}>
+            <UserCircle className="h-4 w-4 mr-1" /> My Portal
+          </Button>
           <Button variant="outline" onClick={() => window.location.href = "/hr/payroll"}>
             <Layers className="h-4 w-4 mr-1" /> Payroll
           </Button>

--- a/client/src/pages/hr/HRHub.tsx
+++ b/client/src/pages/hr/HRHub.tsx
@@ -1,9 +1,16 @@
 import { lazy, Suspense } from "react";
 import { Loader2 } from "lucide-react";
+import { useAuth } from "@/_core/hooks/useAuth";
 
 const Employees = lazy(() => import("./Employees"));
+const EmployeePortal = lazy(() => import("./EmployeePortal"));
+
+const MANAGER_ROLES = ["admin", "exec", "finance"];
 
 export default function HRHub() {
+  const { user } = useAuth();
+  const isManager = user ? MANAGER_ROLES.includes(user.role) : false;
+
   return (
     <Suspense
       fallback={
@@ -12,7 +19,7 @@ export default function HRHub() {
         </div>
       }
     >
-      <Employees />
+      {isManager ? <Employees /> : <EmployeePortal />}
     </Suspense>
   );
 }

--- a/client/src/pages/hr/HRHub.tsx
+++ b/client/src/pages/hr/HRHub.tsx
@@ -8,9 +8,15 @@ const EmployeePortal = lazy(() => import("./EmployeePortal"));
 const MANAGER_ROLES = ["admin", "exec", "finance"];
 
 export default function HRHub() {
-  const { user } = useAuth();
+  const { user, loading } = useAuth();
   const isManager = user ? MANAGER_ROLES.includes(user.role) : false;
 
+
+  if (loading) return (
+    <div className="flex items-center justify-center py-12">
+      <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+    </div>
+  );
   return (
     <Suspense
       fallback={

--- a/drizzle/0032_employee_portal.sql
+++ b/drizzle/0032_employee_portal.sql
@@ -95,3 +95,45 @@ CREATE TABLE IF NOT EXISTS `employee_emergency_contacts` (
   `updatedAt` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   CONSTRAINT `employee_emergency_contacts_id` PRIMARY KEY(`id`)
 );
+--> statement-breakpoint
+
+ALTER TABLE `pto_balances`
+  ADD CONSTRAINT `pto_balances_employeeId_employees_id_fk`
+  FOREIGN KEY (`employeeId`) REFERENCES `employees`(`id`)
+  ON DELETE NO ACTION ON UPDATE NO ACTION;
+--> statement-breakpoint
+
+ALTER TABLE `leave_requests`
+  ADD CONSTRAINT `leave_requests_employeeId_employees_id_fk`
+  FOREIGN KEY (`employeeId`) REFERENCES `employees`(`id`)
+  ON DELETE NO ACTION ON UPDATE NO ACTION;
+--> statement-breakpoint
+
+ALTER TABLE `leave_requests`
+  ADD CONSTRAINT `leave_requests_approverId_users_id_fk`
+  FOREIGN KEY (`approverId`) REFERENCES `users`(`id`)
+  ON DELETE NO ACTION ON UPDATE NO ACTION;
+--> statement-breakpoint
+
+ALTER TABLE `onboarding_tasks`
+  ADD CONSTRAINT `onboarding_tasks_employeeId_employees_id_fk`
+  FOREIGN KEY (`employeeId`) REFERENCES `employees`(`id`)
+  ON DELETE NO ACTION ON UPDATE NO ACTION;
+--> statement-breakpoint
+
+ALTER TABLE `onboarding_tasks`
+  ADD CONSTRAINT `onboarding_tasks_createdBy_users_id_fk`
+  FOREIGN KEY (`createdBy`) REFERENCES `users`(`id`)
+  ON DELETE NO ACTION ON UPDATE NO ACTION;
+--> statement-breakpoint
+
+ALTER TABLE `employee_benefits`
+  ADD CONSTRAINT `employee_benefits_employeeId_employees_id_fk`
+  FOREIGN KEY (`employeeId`) REFERENCES `employees`(`id`)
+  ON DELETE NO ACTION ON UPDATE NO ACTION;
+--> statement-breakpoint
+
+ALTER TABLE `employee_emergency_contacts`
+  ADD CONSTRAINT `employee_emergency_contacts_employeeId_employees_id_fk`
+  FOREIGN KEY (`employeeId`) REFERENCES `employees`(`id`)
+  ON DELETE NO ACTION ON UPDATE NO ACTION;

--- a/drizzle/0032_employee_portal.sql
+++ b/drizzle/0032_employee_portal.sql
@@ -137,3 +137,10 @@ ALTER TABLE `employee_emergency_contacts`
   ADD CONSTRAINT `employee_emergency_contacts_employeeId_employees_id_fk`
   FOREIGN KEY (`employeeId`) REFERENCES `employees`(`id`)
   ON DELETE NO ACTION ON UPDATE NO ACTION;
+
+-- Indexes for efficient per-employee queries
+CREATE INDEX `leave_requests_employeeId_idx` ON `leave_requests` (`employeeId`);
+CREATE INDEX `leave_requests_status_idx` ON `leave_requests` (`status`);
+CREATE INDEX `onboarding_tasks_employeeId_idx` ON `onboarding_tasks` (`employeeId`);
+CREATE INDEX `employee_benefits_employeeId_idx` ON `employee_benefits` (`employeeId`);
+CREATE INDEX `employee_emergency_contacts_employeeId_idx` ON `employee_emergency_contacts` (`employeeId`);

--- a/drizzle/0032_employee_portal.sql
+++ b/drizzle/0032_employee_portal.sql
@@ -1,0 +1,97 @@
+-- Migration 0032: Employee Portal tables
+-- Adds self-service HR tables: PTO balances, leave requests, onboarding tasks,
+-- benefits enrollment, emergency contacts, and payslip fields on existing
+-- employee_payments table.
+
+ALTER TABLE `employee_payments`
+  ADD COLUMN `grossAmount` decimal(15,2),
+  ADD COLUMN `taxWithheld` decimal(15,2),
+  ADD COLUMN `otherDeductions` decimal(15,2),
+  ADD COLUMN `payslipUrl` text;
+--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS `pto_balances` (
+  `id` int AUTO_INCREMENT NOT NULL,
+  `employeeId` int NOT NULL,
+  `leaveType` enum('vacation','sick','personal','parental','bereavement','unpaid','other') NOT NULL,
+  `year` int NOT NULL,
+  `accruedHours` decimal(8,2) NOT NULL DEFAULT '0',
+  `usedHours` decimal(8,2) NOT NULL DEFAULT '0',
+  `pendingHours` decimal(8,2) NOT NULL DEFAULT '0',
+  `carryOverHours` decimal(8,2) NOT NULL DEFAULT '0',
+  `notes` text,
+  `createdAt` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updatedAt` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  CONSTRAINT `pto_balances_id` PRIMARY KEY(`id`),
+  CONSTRAINT `pto_balances_emp_type_year_unique` UNIQUE(`employeeId`,`leaveType`,`year`)
+);
+--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS `leave_requests` (
+  `id` int AUTO_INCREMENT NOT NULL,
+  `employeeId` int NOT NULL,
+  `leaveType` enum('vacation','sick','personal','parental','bereavement','unpaid','other') NOT NULL,
+  `startDate` timestamp NOT NULL,
+  `endDate` timestamp NOT NULL,
+  `hours` decimal(8,2) NOT NULL,
+  `reason` text,
+  `status` enum('pending','approved','rejected','cancelled') NOT NULL DEFAULT 'pending',
+  `approverId` int,
+  `approvedAt` timestamp,
+  `rejectionReason` text,
+  `createdAt` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updatedAt` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  CONSTRAINT `leave_requests_id` PRIMARY KEY(`id`)
+);
+--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS `onboarding_tasks` (
+  `id` int AUTO_INCREMENT NOT NULL,
+  `employeeId` int NOT NULL,
+  `title` varchar(255) NOT NULL,
+  `description` text,
+  `category` enum('paperwork','training','equipment','access','introduction','acknowledgment','other') NOT NULL DEFAULT 'other',
+  `dueDate` timestamp,
+  `status` enum('pending','in_progress','completed','skipped') NOT NULL DEFAULT 'pending',
+  `completedAt` timestamp,
+  `sortOrder` int NOT NULL DEFAULT 0,
+  `createdBy` int,
+  `createdAt` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updatedAt` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  CONSTRAINT `onboarding_tasks_id` PRIMARY KEY(`id`)
+);
+--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS `employee_benefits` (
+  `id` int AUTO_INCREMENT NOT NULL,
+  `employeeId` int NOT NULL,
+  `benefitType` enum('health','dental','vision','retirement_401k','life_insurance','disability','hsa','fsa','commuter','other') NOT NULL,
+  `plan` varchar(255),
+  `carrier` varchar(255),
+  `coverageLevel` enum('employee_only','employee_spouse','employee_children','family','waived'),
+  `employeeContribution` decimal(15,2),
+  `employerContribution` decimal(15,2),
+  `contributionFrequency` enum('per_paycheck','monthly','annual') DEFAULT 'per_paycheck',
+  `effectiveDate` timestamp,
+  `endDate` timestamp,
+  `enrollmentStatus` enum('enrolled','pending','waived','terminated') NOT NULL DEFAULT 'pending',
+  `notes` text,
+  `createdAt` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updatedAt` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  CONSTRAINT `employee_benefits_id` PRIMARY KEY(`id`)
+);
+--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS `employee_emergency_contacts` (
+  `id` int AUTO_INCREMENT NOT NULL,
+  `employeeId` int NOT NULL,
+  `name` varchar(255) NOT NULL,
+  `relationship` varchar(64),
+  `phone` varchar(32),
+  `email` varchar(320),
+  `address` text,
+  `isPrimary` boolean NOT NULL DEFAULT false,
+  `createdAt` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updatedAt` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  CONSTRAINT `employee_emergency_contacts_id` PRIMARY KEY(`id`)
+);

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -705,7 +705,7 @@ export const leaveRequests = mysqlTable("leave_requests", {
   hours: decimal("hours", { precision: 8, scale: 2 }).notNull(),
   reason: text("reason"),
   status: mysqlEnum("status", ["pending", "approved", "rejected", "cancelled"]).default("pending").notNull(),
-  approverId: int("approverId"),
+  approverId: int("approverId").references(() => users.id),
   approvedAt: timestamp("approvedAt"),
   rejectionReason: text("rejectionReason"),
   createdAt: timestamp("createdAt").defaultNow().notNull(),
@@ -722,7 +722,7 @@ export const onboardingTasks = mysqlTable("onboarding_tasks", {
   status: mysqlEnum("status", ["pending", "in_progress", "completed", "skipped"]).default("pending").notNull(),
   completedAt: timestamp("completedAt"),
   sortOrder: int("sortOrder").default(0).notNull(),
-  createdBy: int("createdBy"),
+  createdBy: int("createdBy").references(() => users.id),
   createdAt: timestamp("createdAt").defaultNow().notNull(),
   updatedAt: timestamp("updatedAt").defaultNow().onUpdateNow().notNull(),
 });

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -670,8 +670,89 @@ export const employeePayments = mysqlTable("employee_payments", {
   payPeriodEnd: timestamp("payPeriodEnd"),
   paymentMethod: mysqlEnum("paymentMethod", ["check", "direct_deposit", "wire", "other"]).default("direct_deposit"),
   status: mysqlEnum("status", ["pending", "processed", "cancelled"]).default("pending").notNull(),
+  grossAmount: decimal("grossAmount", { precision: 15, scale: 2 }),
+  taxWithheld: decimal("taxWithheld", { precision: 15, scale: 2 }),
+  otherDeductions: decimal("otherDeductions", { precision: 15, scale: 2 }),
+  payslipUrl: text("payslipUrl"),
   notes: text("notes"),
   createdBy: int("createdBy"),
+  createdAt: timestamp("createdAt").defaultNow().notNull(),
+  updatedAt: timestamp("updatedAt").defaultNow().onUpdateNow().notNull(),
+});
+
+// PTO balance per employee per leave type per year
+export const ptoBalances = mysqlTable("pto_balances", {
+  id: int("id").autoincrement().primaryKey(),
+  employeeId: int("employeeId").notNull().references(() => employees.id),
+  leaveType: mysqlEnum("leaveType", ["vacation", "sick", "personal", "parental", "bereavement", "unpaid", "other"]).notNull(),
+  year: int("year").notNull(),
+  accruedHours: decimal("accruedHours", { precision: 8, scale: 2 }).default("0").notNull(),
+  usedHours: decimal("usedHours", { precision: 8, scale: 2 }).default("0").notNull(),
+  pendingHours: decimal("pendingHours", { precision: 8, scale: 2 }).default("0").notNull(),
+  carryOverHours: decimal("carryOverHours", { precision: 8, scale: 2 }).default("0").notNull(),
+  notes: text("notes"),
+  createdAt: timestamp("createdAt").defaultNow().notNull(),
+  updatedAt: timestamp("updatedAt").defaultNow().onUpdateNow().notNull(),
+});
+
+export const leaveRequests = mysqlTable("leave_requests", {
+  id: int("id").autoincrement().primaryKey(),
+  employeeId: int("employeeId").notNull().references(() => employees.id),
+  leaveType: mysqlEnum("leaveType", ["vacation", "sick", "personal", "parental", "bereavement", "unpaid", "other"]).notNull(),
+  startDate: timestamp("startDate").notNull(),
+  endDate: timestamp("endDate").notNull(),
+  hours: decimal("hours", { precision: 8, scale: 2 }).notNull(),
+  reason: text("reason"),
+  status: mysqlEnum("status", ["pending", "approved", "rejected", "cancelled"]).default("pending").notNull(),
+  approverId: int("approverId"),
+  approvedAt: timestamp("approvedAt"),
+  rejectionReason: text("rejectionReason"),
+  createdAt: timestamp("createdAt").defaultNow().notNull(),
+  updatedAt: timestamp("updatedAt").defaultNow().onUpdateNow().notNull(),
+});
+
+export const onboardingTasks = mysqlTable("onboarding_tasks", {
+  id: int("id").autoincrement().primaryKey(),
+  employeeId: int("employeeId").notNull().references(() => employees.id),
+  title: varchar("title", { length: 255 }).notNull(),
+  description: text("description"),
+  category: mysqlEnum("category", ["paperwork", "training", "equipment", "access", "introduction", "acknowledgment", "other"]).default("other").notNull(),
+  dueDate: timestamp("dueDate"),
+  status: mysqlEnum("status", ["pending", "in_progress", "completed", "skipped"]).default("pending").notNull(),
+  completedAt: timestamp("completedAt"),
+  sortOrder: int("sortOrder").default(0).notNull(),
+  createdBy: int("createdBy"),
+  createdAt: timestamp("createdAt").defaultNow().notNull(),
+  updatedAt: timestamp("updatedAt").defaultNow().onUpdateNow().notNull(),
+});
+
+export const employeeBenefits = mysqlTable("employee_benefits", {
+  id: int("id").autoincrement().primaryKey(),
+  employeeId: int("employeeId").notNull().references(() => employees.id),
+  benefitType: mysqlEnum("benefitType", ["health", "dental", "vision", "retirement_401k", "life_insurance", "disability", "hsa", "fsa", "commuter", "other"]).notNull(),
+  plan: varchar("plan", { length: 255 }),
+  carrier: varchar("carrier", { length: 255 }),
+  coverageLevel: mysqlEnum("coverageLevel", ["employee_only", "employee_spouse", "employee_children", "family", "waived"]),
+  employeeContribution: decimal("employeeContribution", { precision: 15, scale: 2 }),
+  employerContribution: decimal("employerContribution", { precision: 15, scale: 2 }),
+  contributionFrequency: mysqlEnum("contributionFrequency", ["per_paycheck", "monthly", "annual"]).default("per_paycheck"),
+  effectiveDate: timestamp("effectiveDate"),
+  endDate: timestamp("endDate"),
+  enrollmentStatus: mysqlEnum("enrollmentStatus", ["enrolled", "pending", "waived", "terminated"]).default("pending").notNull(),
+  notes: text("notes"),
+  createdAt: timestamp("createdAt").defaultNow().notNull(),
+  updatedAt: timestamp("updatedAt").defaultNow().onUpdateNow().notNull(),
+});
+
+export const employeeEmergencyContacts = mysqlTable("employee_emergency_contacts", {
+  id: int("id").autoincrement().primaryKey(),
+  employeeId: int("employeeId").notNull().references(() => employees.id),
+  name: varchar("name", { length: 255 }).notNull(),
+  relationship: varchar("relationship", { length: 64 }),
+  phone: varchar("phone", { length: 32 }),
+  email: varchar("email", { length: 320 }),
+  address: text("address"),
+  isPrimary: boolean("isPrimary").default(false).notNull(),
   createdAt: timestamp("createdAt").defaultNow().notNull(),
   updatedAt: timestamp("updatedAt").defaultNow().onUpdateNow().notNull(),
 });

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -693,8 +693,9 @@ export const ptoBalances = mysqlTable("pto_balances", {
   notes: text("notes"),
   createdAt: timestamp("createdAt").defaultNow().notNull(),
   updatedAt: timestamp("updatedAt").defaultNow().onUpdateNow().notNull(),
-});
-
+}, (table) => ({
+  employeeLeaveYearIdx: uniqueIndex("pto_balances_employee_leave_year_idx").on(table.employeeId, table.leaveType, table.year),
+}));
 export const leaveRequests = mysqlTable("leave_requests", {
   id: int("id").autoincrement().primaryKey(),
   employeeId: int("employeeId").notNull().references(() => employees.id),

--- a/server/db.ts
+++ b/server/db.ts
@@ -6,6 +6,7 @@ import {
   orders, orderItems, inventory, warehouses, productionBatches,
   purchaseOrders, purchaseOrderItems, shipments,
   departments, employees, compensationHistory, employeePayments,
+  ptoBalances, leaveRequests, onboardingTasks, employeeBenefits, employeeEmergencyContacts,
   contracts, contractKeyDates, disputes, documents,
   projects, projectMilestones, projectTasks,
   auditLogs, notifications, integrationConfigs, aiConversations, aiMessages,
@@ -1276,6 +1277,197 @@ export async function createEmployeePayment(data: typeof employeePayments.$infer
   if (!db) throw new Error("Database not available");
   const result = await db.insert(employeePayments).values(data);
   return { id: result[0].insertId };
+}
+
+// ============================================
+// HR - EMPLOYEE PORTAL (self-service)
+// ============================================
+
+export async function getEmployeeByUserId(userId: number) {
+  const db = await getDb();
+  if (!db) return undefined;
+  const result = await db.select().from(employees).where(eq(employees.userId, userId)).limit(1);
+  return result[0];
+}
+
+export async function getPtoBalances(employeeId: number, year?: number) {
+  const db = await getDb();
+  if (!db) return [];
+  const conds = [eq(ptoBalances.employeeId, employeeId)];
+  if (year !== undefined) conds.push(eq(ptoBalances.year, year));
+  return db.select().from(ptoBalances).where(and(...conds)).orderBy(ptoBalances.leaveType);
+}
+
+export async function upsertPtoBalance(data: typeof ptoBalances.$inferInsert) {
+  const db = await getDb();
+  if (!db) throw new Error("Database not available");
+  const existing = await db
+    .select()
+    .from(ptoBalances)
+    .where(
+      and(
+        eq(ptoBalances.employeeId, data.employeeId),
+        eq(ptoBalances.leaveType, data.leaveType),
+        eq(ptoBalances.year, data.year),
+      ),
+    )
+    .limit(1);
+  if (existing[0]) {
+    await db.update(ptoBalances).set(data).where(eq(ptoBalances.id, existing[0].id));
+    return { id: existing[0].id };
+  }
+  const result = await db.insert(ptoBalances).values(data);
+  return { id: result[0].insertId };
+}
+
+export async function adjustPtoBalance(
+  employeeId: number,
+  leaveType: typeof ptoBalances.$inferInsert["leaveType"],
+  year: number,
+  deltas: { used?: number; pending?: number },
+) {
+  const db = await getDb();
+  if (!db) return;
+  const existing = await db
+    .select()
+    .from(ptoBalances)
+    .where(
+      and(
+        eq(ptoBalances.employeeId, employeeId),
+        eq(ptoBalances.leaveType, leaveType),
+        eq(ptoBalances.year, year),
+      ),
+    )
+    .limit(1);
+  if (!existing[0]) return;
+  const updates: Record<string, unknown> = {};
+  if (deltas.used !== undefined) {
+    updates.usedHours = sql`${ptoBalances.usedHours} + ${deltas.used}`;
+  }
+  if (deltas.pending !== undefined) {
+    updates.pendingHours = sql`${ptoBalances.pendingHours} + ${deltas.pending}`;
+  }
+  if (Object.keys(updates).length === 0) return;
+  await db.update(ptoBalances).set(updates).where(eq(ptoBalances.id, existing[0].id));
+}
+
+export async function getLeaveRequests(filters?: { employeeId?: number; status?: string }) {
+  const db = await getDb();
+  if (!db) return [];
+  const conds = [];
+  if (filters?.employeeId) conds.push(eq(leaveRequests.employeeId, filters.employeeId));
+  if (filters?.status) conds.push(eq(leaveRequests.status, filters.status as any));
+  if (conds.length > 0) {
+    return db.select().from(leaveRequests).where(and(...conds)).orderBy(desc(leaveRequests.startDate));
+  }
+  return db.select().from(leaveRequests).orderBy(desc(leaveRequests.startDate));
+}
+
+export async function getLeaveRequestById(id: number) {
+  const db = await getDb();
+  if (!db) return undefined;
+  const result = await db.select().from(leaveRequests).where(eq(leaveRequests.id, id)).limit(1);
+  return result[0];
+}
+
+export async function createLeaveRequest(data: typeof leaveRequests.$inferInsert) {
+  const db = await getDb();
+  if (!db) throw new Error("Database not available");
+  const result = await db.insert(leaveRequests).values(data);
+  return { id: result[0].insertId };
+}
+
+export async function updateLeaveRequest(id: number, data: Partial<typeof leaveRequests.$inferInsert>) {
+  const db = await getDb();
+  if (!db) return;
+  await db.update(leaveRequests).set(data).where(eq(leaveRequests.id, id));
+}
+
+export async function getOnboardingTasks(employeeId: number) {
+  const db = await getDb();
+  if (!db) return [];
+  return db
+    .select()
+    .from(onboardingTasks)
+    .where(eq(onboardingTasks.employeeId, employeeId))
+    .orderBy(onboardingTasks.sortOrder, onboardingTasks.id);
+}
+
+export async function createOnboardingTask(data: typeof onboardingTasks.$inferInsert) {
+  const db = await getDb();
+  if (!db) throw new Error("Database not available");
+  const result = await db.insert(onboardingTasks).values(data);
+  return { id: result[0].insertId };
+}
+
+export async function updateOnboardingTask(
+  id: number,
+  data: Partial<typeof onboardingTasks.$inferInsert>,
+) {
+  const db = await getDb();
+  if (!db) return;
+  await db.update(onboardingTasks).set(data).where(eq(onboardingTasks.id, id));
+}
+
+export async function getEmployeeBenefits(employeeId: number) {
+  const db = await getDb();
+  if (!db) return [];
+  return db
+    .select()
+    .from(employeeBenefits)
+    .where(eq(employeeBenefits.employeeId, employeeId))
+    .orderBy(employeeBenefits.benefitType);
+}
+
+export async function upsertEmployeeBenefit(data: typeof employeeBenefits.$inferInsert) {
+  const db = await getDb();
+  if (!db) throw new Error("Database not available");
+  const result = await db.insert(employeeBenefits).values(data);
+  return { id: result[0].insertId };
+}
+
+export async function updateEmployeeBenefit(
+  id: number,
+  data: Partial<typeof employeeBenefits.$inferInsert>,
+) {
+  const db = await getDb();
+  if (!db) return;
+  await db.update(employeeBenefits).set(data).where(eq(employeeBenefits.id, id));
+}
+
+export async function getEmergencyContacts(employeeId: number) {
+  const db = await getDb();
+  if (!db) return [];
+  return db
+    .select()
+    .from(employeeEmergencyContacts)
+    .where(eq(employeeEmergencyContacts.employeeId, employeeId))
+    .orderBy(desc(employeeEmergencyContacts.isPrimary), employeeEmergencyContacts.name);
+}
+
+export async function createEmergencyContact(data: typeof employeeEmergencyContacts.$inferInsert) {
+  const db = await getDb();
+  if (!db) throw new Error("Database not available");
+  const result = await db.insert(employeeEmergencyContacts).values(data);
+  return { id: result[0].insertId };
+}
+
+export async function updateEmergencyContact(
+  id: number,
+  data: Partial<typeof employeeEmergencyContacts.$inferInsert>,
+) {
+  const db = await getDb();
+  if (!db) return;
+  await db
+    .update(employeeEmergencyContacts)
+    .set(data)
+    .where(eq(employeeEmergencyContacts.id, id));
+}
+
+export async function deleteEmergencyContact(id: number) {
+  const db = await getDb();
+  if (!db) return;
+  await db.delete(employeeEmergencyContacts).where(eq(employeeEmergencyContacts.id, id));
 }
 
 // ============================================

--- a/server/db/hr.ts
+++ b/server/db/hr.ts
@@ -274,3 +274,121 @@ export async function deleteEmergencyContact(id: number) {
   if (!db) return;
   await db.delete(employeeEmergencyContacts).where(eq(employeeEmergencyContacts.id, id));
 }
+
+// ========================== 
+// Transactional operations
+// ==========================
+
+/**
+ * Atomically create a leave request and adjust the PTO pending balance.
+ * Both operations are wrapped in a DB transaction so a balance-adjustment failure
+ * cannot leave the request in an orphaned state.
+ */
+export async function createLeaveRequestWithPtoAdjustment(
+  leaveData: typeof leaveRequests.$inferInsert,
+  ptoAdjust: { employeeId: number; leaveType: typeof ptoBalances.$inferInsert["leaveType"]; year: number; hours: number },
+) {
+  const db = await getDb();
+  if (!db) throw new Error("Database not available");
+  return db.transaction(async (tx) => {
+    const result = await tx.insert(leaveRequests).values(leaveData);
+    const existing = await tx
+      .select()
+      .from(ptoBalances)
+      .where(and(
+        eq(ptoBalances.employeeId, ptoAdjust.employeeId),
+        eq(ptoBalances.leaveType, ptoAdjust.leaveType),
+        eq(ptoBalances.year, ptoAdjust.year),
+      ))
+      .limit(1);
+    if (!existing[0]) throw new Error(`No PTO balance record found for employee ${ptoAdjust.employeeId}, leaveType ${ptoAdjust.leaveType}, year ${ptoAdjust.year}`);
+    await tx
+      .update(ptoBalances)
+      .set({ pendingHours: sql`${ptoBalances.pendingHours} + ${ptoAdjust.hours}` })
+      .where(eq(ptoBalances.id, existing[0].id));
+    return { id: result[0].insertId };
+  });
+}
+
+/**
+ * Atomically update a leave request decision and adjust the PTO used/pending balances.
+ */
+export async function decideLeaveRequestWithPtoAdjustment(
+  requestId: number,
+  decision: { status: string; approverId: number; rejectionReason?: string | null },
+  ptoAdjust: { employeeId: number; leaveType: typeof ptoBalances.$inferInsert["leaveType"]; year: number; hours: number; approved: boolean },
+) {
+  const db = await getDb();
+  if (!db) throw new Error("Database not available");
+  return db.transaction(async (tx) => {
+    await tx
+      .update(leaveRequests)
+      .set({ status: decision.status as any, approverId: decision.approverId, approvedAt: new Date(), rejectionReason: decision.rejectionReason })
+      .where(eq(leaveRequests.id, requestId));
+    const existing = await tx
+      .select()
+      .from(ptoBalances)
+      .where(and(
+        eq(ptoBalances.employeeId, ptoAdjust.employeeId),
+        eq(ptoBalances.leaveType, ptoAdjust.leaveType),
+        eq(ptoBalances.year, ptoAdjust.year),
+      ))
+      .limit(1);
+    if (!existing[0]) throw new Error(`No PTO balance found for employee ${ptoAdjust.employeeId}`);
+    if (ptoAdjust.approved) {
+      await tx
+        .update(ptoBalances)
+        .set({
+          pendingHours: sql`${ptoBalances.pendingHours} - ${ptoAdjust.hours}`,
+          usedHours: sql`${ptoBalances.usedHours} + ${ptoAdjust.hours}`,
+        })
+        .where(eq(ptoBalances.id, existing[0].id));
+    } else {
+      await tx
+        .update(ptoBalances)
+        .set({ pendingHours: sql`${ptoBalances.pendingHours} - ${ptoAdjust.hours}` })
+        .where(eq(ptoBalances.id, existing[0].id));
+    }
+    return { success: true };
+  });
+}
+
+/**
+ * Atomically cancel a leave request and restore PTO pending/used balances.
+ */
+export async function cancelLeaveRequestWithPtoRestore(
+  requestId: number,
+  ptoRestore: { employeeId: number; leaveType: typeof ptoBalances.$inferInsert["leaveType"]; year: number; hours: number; wasApproved: boolean },
+) {
+  const db = await getDb();
+  if (!db) throw new Error("Database not available");
+  return db.transaction(async (tx) => {
+    await tx
+      .update(leaveRequests)
+      .set({ status: "cancelled" as any })
+      .where(eq(leaveRequests.id, requestId));
+    const existing = await tx
+      .select()
+      .from(ptoBalances)
+      .where(and(
+        eq(ptoBalances.employeeId, ptoRestore.employeeId),
+        eq(ptoBalances.leaveType, ptoRestore.leaveType),
+        eq(ptoBalances.year, ptoRestore.year),
+      ))
+      .limit(1);
+    if (existing[0]) {
+      if (ptoRestore.wasApproved) {
+        await tx
+          .update(ptoBalances)
+          .set({ usedHours: sql`${ptoBalances.usedHours} - ${ptoRestore.hours}` })
+          .where(eq(ptoBalances.id, existing[0].id));
+      } else {
+        await tx
+          .update(ptoBalances)
+          .set({ pendingHours: sql`${ptoBalances.pendingHours} - ${ptoRestore.hours}` })
+          .where(eq(ptoBalances.id, existing[0].id));
+      }
+    }
+    return { success: true };
+  });
+}

--- a/server/db/hr.ts
+++ b/server/db/hr.ts
@@ -1,5 +1,16 @@
-import { eq, and, desc } from "drizzle-orm";
-import { departments, employees, InsertEmployee, compensationHistory, employeePayments } from "../../drizzle/schema";
+import { eq, and, desc, sql } from "drizzle-orm";
+import {
+  departments,
+  employees,
+  InsertEmployee,
+  compensationHistory,
+  employeePayments,
+  ptoBalances,
+  leaveRequests,
+  onboardingTasks,
+  employeeBenefits,
+  employeeEmergencyContacts,
+} from "../../drizzle/schema";
 import { getDb } from "./connection";
 
 export async function getDepartments(companyId?: number) {
@@ -72,4 +83,182 @@ export async function createEmployeePayment(data: typeof employeePayments.$infer
   if (!db) throw new Error("Database not available");
   const result = await db.insert(employeePayments).values(data);
   return { id: result[0].insertId };
+}
+
+// ==========================
+// Employee Portal helpers
+// ==========================
+
+export async function getEmployeeByUserId(userId: number) {
+  const db = await getDb();
+  if (!db) return undefined;
+  const result = await db.select().from(employees).where(eq(employees.userId, userId)).limit(1);
+  return result[0];
+}
+
+export async function getPtoBalances(employeeId: number, year?: number) {
+  const db = await getDb();
+  if (!db) return [];
+  const conds = [eq(ptoBalances.employeeId, employeeId)];
+  if (year) conds.push(eq(ptoBalances.year, year));
+  return db.select().from(ptoBalances).where(and(...conds)).orderBy(ptoBalances.leaveType);
+}
+
+export async function upsertPtoBalance(data: typeof ptoBalances.$inferInsert) {
+  const db = await getDb();
+  if (!db) throw new Error("Database not available");
+  const existing = await db
+    .select()
+    .from(ptoBalances)
+    .where(and(
+      eq(ptoBalances.employeeId, data.employeeId),
+      eq(ptoBalances.leaveType, data.leaveType),
+      eq(ptoBalances.year, data.year),
+    ))
+    .limit(1);
+  if (existing[0]) {
+    await db.update(ptoBalances).set(data).where(eq(ptoBalances.id, existing[0].id));
+    return { id: existing[0].id };
+  }
+  const result = await db.insert(ptoBalances).values(data);
+  return { id: result[0].insertId };
+}
+
+export async function adjustPtoBalance(
+  employeeId: number,
+  leaveType: typeof ptoBalances.$inferInsert["leaveType"],
+  year: number,
+  deltas: { used?: number; pending?: number },
+) {
+  const db = await getDb();
+  if (!db) return;
+  const existing = await db
+    .select()
+    .from(ptoBalances)
+    .where(and(
+      eq(ptoBalances.employeeId, employeeId),
+      eq(ptoBalances.leaveType, leaveType),
+      eq(ptoBalances.year, year),
+    ))
+    .limit(1);
+  if (!existing[0]) return;
+  const updates: Record<string, unknown> = {};
+  if (deltas.used !== undefined) {
+    updates.usedHours = sql`${ptoBalances.usedHours} + ${deltas.used}`;
+  }
+  if (deltas.pending !== undefined) {
+    updates.pendingHours = sql`${ptoBalances.pendingHours} + ${deltas.pending}`;
+  }
+  await db.update(ptoBalances).set(updates).where(eq(ptoBalances.id, existing[0].id));
+}
+
+export async function getLeaveRequests(filters?: { employeeId?: number; status?: string }) {
+  const db = await getDb();
+  if (!db) return [];
+  const conds = [];
+  if (filters?.employeeId) conds.push(eq(leaveRequests.employeeId, filters.employeeId));
+  if (filters?.status) conds.push(eq(leaveRequests.status, filters.status as any));
+  const q = db.select().from(leaveRequests);
+  if (conds.length > 0) {
+    return q.where(and(...conds)).orderBy(desc(leaveRequests.startDate));
+  }
+  return q.orderBy(desc(leaveRequests.startDate));
+}
+
+export async function getLeaveRequestById(id: number) {
+  const db = await getDb();
+  if (!db) return undefined;
+  const result = await db.select().from(leaveRequests).where(eq(leaveRequests.id, id)).limit(1);
+  return result[0];
+}
+
+export async function createLeaveRequest(data: typeof leaveRequests.$inferInsert) {
+  const db = await getDb();
+  if (!db) throw new Error("Database not available");
+  const result = await db.insert(leaveRequests).values(data);
+  return { id: result[0].insertId };
+}
+
+export async function updateLeaveRequest(id: number, data: Partial<typeof leaveRequests.$inferInsert>) {
+  const db = await getDb();
+  if (!db) return;
+  await db.update(leaveRequests).set(data).where(eq(leaveRequests.id, id));
+}
+
+export async function getOnboardingTasks(employeeId: number) {
+  const db = await getDb();
+  if (!db) return [];
+  return db
+    .select()
+    .from(onboardingTasks)
+    .where(eq(onboardingTasks.employeeId, employeeId))
+    .orderBy(onboardingTasks.sortOrder, onboardingTasks.id);
+}
+
+export async function createOnboardingTask(data: typeof onboardingTasks.$inferInsert) {
+  const db = await getDb();
+  if (!db) throw new Error("Database not available");
+  const result = await db.insert(onboardingTasks).values(data);
+  return { id: result[0].insertId };
+}
+
+export async function updateOnboardingTask(id: number, data: Partial<typeof onboardingTasks.$inferInsert>) {
+  const db = await getDb();
+  if (!db) return;
+  await db.update(onboardingTasks).set(data).where(eq(onboardingTasks.id, id));
+}
+
+export async function getEmployeeBenefits(employeeId: number) {
+  const db = await getDb();
+  if (!db) return [];
+  return db
+    .select()
+    .from(employeeBenefits)
+    .where(eq(employeeBenefits.employeeId, employeeId))
+    .orderBy(employeeBenefits.benefitType);
+}
+
+export async function upsertEmployeeBenefit(data: typeof employeeBenefits.$inferInsert) {
+  const db = await getDb();
+  if (!db) throw new Error("Database not available");
+  const result = await db.insert(employeeBenefits).values(data);
+  return { id: result[0].insertId };
+}
+
+export async function updateEmployeeBenefit(id: number, data: Partial<typeof employeeBenefits.$inferInsert>) {
+  const db = await getDb();
+  if (!db) return;
+  await db.update(employeeBenefits).set(data).where(eq(employeeBenefits.id, id));
+}
+
+export async function getEmergencyContacts(employeeId: number) {
+  const db = await getDb();
+  if (!db) return [];
+  return db
+    .select()
+    .from(employeeEmergencyContacts)
+    .where(eq(employeeEmergencyContacts.employeeId, employeeId))
+    .orderBy(desc(employeeEmergencyContacts.isPrimary), employeeEmergencyContacts.name);
+}
+
+export async function createEmergencyContact(data: typeof employeeEmergencyContacts.$inferInsert) {
+  const db = await getDb();
+  if (!db) throw new Error("Database not available");
+  const result = await db.insert(employeeEmergencyContacts).values(data);
+  return { id: result[0].insertId };
+}
+
+export async function updateEmergencyContact(
+  id: number,
+  data: Partial<typeof employeeEmergencyContacts.$inferInsert>,
+) {
+  const db = await getDb();
+  if (!db) return;
+  await db.update(employeeEmergencyContacts).set(data).where(eq(employeeEmergencyContacts.id, id));
+}
+
+export async function deleteEmergencyContact(id: number) {
+  const db = await getDb();
+  if (!db) return;
+  await db.delete(employeeEmergencyContacts).where(eq(employeeEmergencyContacts.id, id));
 }

--- a/server/db/hr.ts
+++ b/server/db/hr.ts
@@ -141,7 +141,7 @@ export async function adjustPtoBalance(
       eq(ptoBalances.year, year),
     ))
     .limit(1);
-  if (!existing[0]) return;
+  if (!existing[0]) throw new Error(`No PTO balance record found for employee ${employeeId}, leaveType ${leaveType}, year ${year}`);
   const updates: Record<string, unknown> = {};
   if (deltas.used !== undefined) {
     updates.usedHours = sql`${ptoBalances.usedHours} + ${deltas.used}`;
@@ -221,6 +221,18 @@ export async function getEmployeeBenefits(employeeId: number) {
 export async function upsertEmployeeBenefit(data: typeof employeeBenefits.$inferInsert) {
   const db = await getDb();
   if (!db) throw new Error("Database not available");
+  const existing = await db
+    .select()
+    .from(employeeBenefits)
+    .where(and(
+      eq(employeeBenefits.employeeId, data.employeeId),
+      eq(employeeBenefits.benefitType, data.benefitType),
+    ))
+    .limit(1);
+  if (existing[0]) {
+    await db.update(employeeBenefits).set(data).where(eq(employeeBenefits.id, existing[0].id));
+    return { id: existing[0].id };
+  }
   const result = await db.insert(employeeBenefits).values(data);
   return { id: result[0].insertId };
 }

--- a/server/employeePortal.test.ts
+++ b/server/employeePortal.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { appRouter } from "./routers";
+import type { TrpcContext } from "./_core/context";
+import * as db from "./db";
+
+type AuthenticatedUser = NonNullable<TrpcContext["user"]>;
+
+function ctxFor(overrides: Partial<AuthenticatedUser> = {}): TrpcContext {
+  const user: AuthenticatedUser = {
+    id: 42,
+    openId: "emp-user",
+    email: "emp@example.com",
+    name: "Employee User",
+    loginMethod: "manus",
+    role: "user",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    lastSignedIn: new Date(),
+    ...overrides,
+  };
+  return {
+    user,
+    req: { protocol: "https", headers: {} } as TrpcContext["req"],
+    res: {} as TrpcContext["res"],
+  };
+}
+
+describe("employeePortal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("me", () => {
+    it("returns the employee linked to the current user", async () => {
+      const caller = appRouter.createCaller(ctxFor());
+      vi.spyOn(db, "getEmployeeByUserId").mockResolvedValue({
+        id: 7,
+        userId: 42,
+        firstName: "Ada",
+        lastName: "Lovelace",
+        departmentId: null,
+      } as any);
+      vi.spyOn(db, "getDepartments").mockResolvedValue([]);
+
+      const result = await caller.employeePortal.me();
+      expect(result?.id).toBe(7);
+      expect(result?.firstName).toBe("Ada");
+    });
+
+    it("returns null when no employee is linked", async () => {
+      const caller = appRouter.createCaller(ctxFor());
+      vi.spyOn(db, "getEmployeeByUserId").mockResolvedValue(undefined);
+
+      const result = await caller.employeePortal.me();
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("submitLeaveRequest", () => {
+    it("creates a request and bumps pending PTO", async () => {
+      const caller = appRouter.createCaller(ctxFor());
+      vi.spyOn(db, "getEmployeeByUserId").mockResolvedValue({ id: 7, userId: 42 } as any);
+      vi.spyOn(db, "createLeaveRequest").mockResolvedValue({ id: 101 });
+      const adjust = vi.spyOn(db, "adjustPtoBalance").mockResolvedValue(undefined);
+      vi.spyOn(db, "createAuditLog").mockResolvedValue({ id: 1 });
+
+      const result = await caller.employeePortal.submitLeaveRequest({
+        leaveType: "vacation",
+        startDate: new Date("2026-06-01"),
+        endDate: new Date("2026-06-03"),
+        hours: 24,
+        reason: "Trip",
+      });
+
+      expect(result.id).toBe(101);
+      expect(adjust).toHaveBeenCalledWith(7, "vacation", 2026, { pending: 24 });
+    });
+
+    it("rejects invalid date ranges", async () => {
+      const caller = appRouter.createCaller(ctxFor());
+      vi.spyOn(db, "getEmployeeByUserId").mockResolvedValue({ id: 7, userId: 42 } as any);
+
+      await expect(
+        caller.employeePortal.submitLeaveRequest({
+          leaveType: "vacation",
+          startDate: new Date("2026-06-05"),
+          endDate: new Date("2026-06-03"),
+          hours: 16,
+        }),
+      ).rejects.toThrow();
+    });
+
+    it("throws when no employee record is linked", async () => {
+      const caller = appRouter.createCaller(ctxFor());
+      vi.spyOn(db, "getEmployeeByUserId").mockResolvedValue(undefined);
+
+      await expect(
+        caller.employeePortal.submitLeaveRequest({
+          leaveType: "sick",
+          startDate: new Date(),
+          endDate: new Date(),
+          hours: 4,
+        }),
+      ).rejects.toThrow(/No employee record/);
+    });
+  });
+
+  describe("cancelLeaveRequest", () => {
+    it("only allows cancelling your own request", async () => {
+      const caller = appRouter.createCaller(ctxFor());
+      vi.spyOn(db, "getEmployeeByUserId").mockResolvedValue({ id: 7, userId: 42 } as any);
+      vi.spyOn(db, "getLeaveRequestById").mockResolvedValue({
+        id: 101,
+        employeeId: 999,
+        leaveType: "vacation",
+        startDate: new Date("2026-06-01"),
+        hours: "8",
+        status: "pending",
+      } as any);
+
+      await expect(
+        caller.employeePortal.cancelLeaveRequest({ id: 101 }),
+      ).rejects.toThrow(/Not your request/);
+    });
+
+    it("refunds pending hours when cancelling a pending request", async () => {
+      const caller = appRouter.createCaller(ctxFor());
+      vi.spyOn(db, "getEmployeeByUserId").mockResolvedValue({ id: 7, userId: 42 } as any);
+      vi.spyOn(db, "getLeaveRequestById").mockResolvedValue({
+        id: 101,
+        employeeId: 7,
+        leaveType: "vacation",
+        startDate: new Date("2026-06-01"),
+        hours: "8",
+        status: "pending",
+      } as any);
+      vi.spyOn(db, "updateLeaveRequest").mockResolvedValue(undefined);
+      const adjust = vi.spyOn(db, "adjustPtoBalance").mockResolvedValue(undefined);
+      vi.spyOn(db, "createAuditLog").mockResolvedValue({ id: 1 });
+
+      await caller.employeePortal.cancelLeaveRequest({ id: 101 });
+      expect(adjust).toHaveBeenCalledWith(7, "vacation", 2026, { pending: -8 });
+    });
+  });
+
+  describe("decideLeaveRequest", () => {
+    it("allows the employee's manager to approve", async () => {
+      const caller = appRouter.createCaller(ctxFor({ id: 10, role: "user" }));
+      vi.spyOn(db, "getLeaveRequestById").mockResolvedValue({
+        id: 101,
+        employeeId: 7,
+        leaveType: "vacation",
+        startDate: new Date("2026-06-01"),
+        hours: "16",
+        status: "pending",
+      } as any);
+      vi.spyOn(db, "getEmployeeById").mockResolvedValue({ id: 7, managerId: 10 } as any);
+      vi.spyOn(db, "updateLeaveRequest").mockResolvedValue(undefined);
+      const adjust = vi.spyOn(db, "adjustPtoBalance").mockResolvedValue(undefined);
+      vi.spyOn(db, "createAuditLog").mockResolvedValue({ id: 1 });
+
+      const result = await caller.employeePortal.decideLeaveRequest({
+        id: 101,
+        decision: "approved",
+      });
+      expect(result.success).toBe(true);
+      expect(adjust).toHaveBeenCalledWith(7, "vacation", 2026, { pending: -16, used: 16 });
+    });
+
+    it("rejects non-managers, non-admins", async () => {
+      const caller = appRouter.createCaller(ctxFor({ id: 999, role: "user" }));
+      vi.spyOn(db, "getLeaveRequestById").mockResolvedValue({
+        id: 101,
+        employeeId: 7,
+        leaveType: "vacation",
+        startDate: new Date("2026-06-01"),
+        hours: "16",
+        status: "pending",
+      } as any);
+      vi.spyOn(db, "getEmployeeById").mockResolvedValue({ id: 7, managerId: 10 } as any);
+
+      await expect(
+        caller.employeePortal.decideLeaveRequest({ id: 101, decision: "approved" }),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe("onboarding", () => {
+    it("marks a task completed", async () => {
+      const caller = appRouter.createCaller(ctxFor());
+      vi.spyOn(db, "getEmployeeByUserId").mockResolvedValue({ id: 7, userId: 42 } as any);
+      vi.spyOn(db, "getOnboardingTasks").mockResolvedValue([
+        { id: 1, employeeId: 7, title: "Sign handbook", status: "pending" } as any,
+      ]);
+      const update = vi.spyOn(db, "updateOnboardingTask").mockResolvedValue(undefined);
+
+      await caller.employeePortal.updateOnboardingTask({ id: 1, status: "completed" });
+      expect(update).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({ status: "completed", completedAt: expect.any(Date) }),
+      );
+    });
+
+    it("prevents editing another employee's task", async () => {
+      const caller = appRouter.createCaller(ctxFor());
+      vi.spyOn(db, "getEmployeeByUserId").mockResolvedValue({ id: 7, userId: 42 } as any);
+      vi.spyOn(db, "getOnboardingTasks").mockResolvedValue([
+        { id: 1, employeeId: 7, title: "Sign handbook", status: "pending" } as any,
+      ]);
+
+      await expect(
+        caller.employeePortal.updateOnboardingTask({ id: 999, status: "completed" }),
+      ).rejects.toThrow(/Not your task/);
+    });
+  });
+});

--- a/server/routers.ts
+++ b/server/routers.ts
@@ -21,6 +21,7 @@ import { addCostLayer, recordCogs, getInventoryValuation, generateCogsPeriodSumm
 import { analyzeNegotiationOpportunity, initiateNegotiation, addNegotiationRound, generateNegotiationDraft } from "./vendorNegotiationService";
 import { autonomousWorkflowRouter } from "./autonomousWorkflowRouter";
 import { agentRouter } from "./agent";
+import { employeePortalRouter } from "./routers/employeePortal";
 import { parseCopackerInventoryEmail, applyCopackerInventoryUpdate } from "./copackerEmailExtractor";
 import { parseTextToPO, createPOPreview, createPOFromPreview } from "./textToPOService";
 import { detectFinancialAnomalies, forecastRevenue, predictCashFlow, classifyTransactions } from "./financeAiService";
@@ -249,6 +250,9 @@ export const appRouter = router({
 
   // Reasoning Agent
   agent: agentRouter,
+
+  // Employee self-service portal
+  employeePortal: employeePortalRouter,
 
   auth: router({
     me: publicProcedure.query(opts => {

--- a/server/routers/employeePortal.ts
+++ b/server/routers/employeePortal.ts
@@ -196,23 +196,25 @@ export const employeePortalRouter = router({
           throw new TRPCError({ code: "BAD_REQUEST", message: "End date is before start date" });
         }
         const employee = await requireEmployee(ctx.user.id);
-        const result = await db.createLeaveRequest({
-          employeeId: employee.id,
-          leaveType: input.leaveType,
-          startDate: input.startDate,
-          endDate: input.endDate,
-          hours: input.hours.toString(),
-          reason: input.reason,
-          status: "pending",
-        });
-        await db.adjustPtoBalance(
-          employee.id,
-          input.leaveType,
-          input.startDate.getFullYear(),
-          { pending: input.hours },
-        );
-        await createAuditLog(ctx.user.id, "create", "leave_request", result.id);
-        return result;
+        const result = await db.createLeaveRequestWithPtoAdjustment(
+      {
+        employeeId: employee.id,
+        leaveType: input.leaveType,
+        startDate: input.startDate,
+        endDate: input.endDate,
+        hours: input.hours.toString(),
+        reason: input.reason,
+        status: "pending",
+      },
+      {
+        employeeId: employee.id,
+        leaveType: input.leaveType,
+        year: input.startDate.getFullYear(),
+        hours: input.hours,
+      },
+    );
+    await createAuditLog(ctx.user.id, "create", "leave_request", result.id);
+    return result;
       }),
 
     cancelLeaveRequest: protectedProcedure
@@ -226,24 +228,19 @@ export const employeePortalRouter = router({
         if (req.status === "cancelled" || req.status === "rejected") {
           return { success: true };
         }
-        await db.updateLeaveRequest(input.id, { status: "cancelled" });
-        if (req.status === "pending") {
-          await db.adjustPtoBalance(
-            employee.id,
-            req.leaveType,
-            new Date(req.startDate).getFullYear(),
-            { pending: -Number(req.hours) },
-          );
-        } else if (req.status === "approved") {
-          await db.adjustPtoBalance(
-            employee.id,
-            req.leaveType,
-            new Date(req.startDate).getFullYear(),
-            { used: -Number(req.hours) },
-          );
-        }
-        await createAuditLog(ctx.user.id, "update", "leave_request", input.id, "cancelled");
-        return { success: true };
+        const wasApproved = req.status === "approved";
+    await db.cancelLeaveRequestWithPtoRestore(
+      input.id,
+      {
+        employeeId: req.employeeId,
+        leaveType: req.leaveType,
+        year: new Date(req.startDate).getFullYear(),
+        hours: Number(req.hours),
+        wasApproved,
+      },
+    );
+    await createAuditLog(ctx.user.id, "update", "leave_request", input.id, "cancelled");
+    return { success: true };
       }),
 
     // Manager/admin action — approve/reject
@@ -266,24 +263,25 @@ export const employeePortalRouter = router({
         if (req.status !== "pending") {
           throw new TRPCError({ code: "BAD_REQUEST", message: "Request already decided" });
         }
-        await db.updateLeaveRequest(input.id, {
-          status: input.decision,
-          approverId: ctx.user.id,
-          approvedAt: new Date(),
-          rejectionReason: input.rejectionReason,
-        });
         const year = new Date(req.startDate).getFullYear();
-        const hours = Number(req.hours);
-        if (input.decision === "approved") {
-          await db.adjustPtoBalance(req.employeeId, req.leaveType, year, {
-            pending: -hours,
-            used: hours,
-          });
-        } else {
-          await db.adjustPtoBalance(req.employeeId, req.leaveType, year, { pending: -hours });
-        }
-        await createAuditLog(ctx.user.id, input.decision === "approved" ? "approve" : "reject", "leave_request", input.id);
-        return { success: true };
+    const hours = Number(req.hours);
+    await db.decideLeaveRequestWithPtoAdjustment(
+      input.id,
+      {
+        status: input.decision,
+        approverId: ctx.user.id,
+        rejectionReason: input.rejectionReason,
+      },
+      {
+        employeeId: req.employeeId,
+        leaveType: req.leaveType,
+        year,
+        hours,
+        approved: input.decision === "approved",
+      },
+    );
+    await createAuditLog(ctx.user.id, input.decision === "approved" ? "approve" : "reject", "leave_request", input.id);
+    return { success: true };
       }),
 
     // ---- Onboarding ----

--- a/server/routers/employeePortal.ts
+++ b/server/routers/employeePortal.ts
@@ -1,0 +1,404 @@
+import { z } from "zod";
+import { TRPCError } from "@trpc/server";
+import * as db from "../db";
+import { router, protectedProcedure, createAuditLog } from "./middleware";
+
+const LEAVE_TYPES = [
+  "vacation",
+  "sick",
+  "personal",
+  "parental",
+  "bereavement",
+  "unpaid",
+  "other",
+] as const;
+
+const BENEFIT_TYPES = [
+  "health",
+  "dental",
+  "vision",
+  "retirement_401k",
+  "life_insurance",
+  "disability",
+  "hsa",
+  "fsa",
+  "commuter",
+  "other",
+] as const;
+
+const COVERAGE_LEVELS = [
+  "employee_only",
+  "employee_spouse",
+  "employee_children",
+  "family",
+  "waived",
+] as const;
+
+const ENROLLMENT_STATUSES = ["enrolled", "pending", "waived", "terminated"] as const;
+
+const ONBOARDING_CATEGORIES = [
+  "paperwork",
+  "training",
+  "equipment",
+  "access",
+  "introduction",
+  "acknowledgment",
+  "other",
+] as const;
+
+const ONBOARDING_STATUSES = ["pending", "in_progress", "completed", "skipped"] as const;
+
+async function requireEmployee(userId: number) {
+  const employee = await db.getEmployeeByUserId(userId);
+  if (!employee) {
+    throw new TRPCError({
+      code: "NOT_FOUND",
+      message: "No employee record linked to this user. Contact HR.",
+    });
+  }
+  return employee;
+}
+
+function canViewEmployee(role: string, actingEmployeeId: number, targetEmployeeId: number) {
+  if (actingEmployeeId === targetEmployeeId) return true;
+  return ["admin", "exec"].includes(role);
+}
+
+export const employeePortalRouter = router({
+    // ---- Profile ----
+    me: protectedProcedure.query(async ({ ctx }) => {
+      const employee = await db.getEmployeeByUserId(ctx.user.id);
+      if (!employee) return null;
+      const department = employee.departmentId
+        ? (await db.getDepartments()).find((d) => d.id === employee.departmentId)
+        : undefined;
+      return { ...employee, department: department ?? null };
+    }),
+
+    updateProfile: protectedProcedure
+      .input(
+        z.object({
+          phone: z.string().optional(),
+          personalEmail: z.string().email().optional().or(z.literal("")),
+          address: z.string().optional(),
+          city: z.string().optional(),
+          state: z.string().optional(),
+          country: z.string().optional(),
+          postalCode: z.string().optional(),
+        }),
+      )
+      .mutation(async ({ input, ctx }) => {
+        const employee = await requireEmployee(ctx.user.id);
+        await db.updateEmployee(employee.id, input);
+        await createAuditLog(ctx.user.id, "update", "employee", employee.id, "self-service profile");
+        return { success: true };
+      }),
+
+    // ---- Emergency contacts ----
+    emergencyContacts: protectedProcedure.query(async ({ ctx }) => {
+      const employee = await requireEmployee(ctx.user.id);
+      return db.getEmergencyContacts(employee.id);
+    }),
+
+    addEmergencyContact: protectedProcedure
+      .input(
+        z.object({
+          name: z.string().min(1),
+          relationship: z.string().optional(),
+          phone: z.string().optional(),
+          email: z.string().email().optional().or(z.literal("")),
+          address: z.string().optional(),
+          isPrimary: z.boolean().optional(),
+        }),
+      )
+      .mutation(async ({ input, ctx }) => {
+        const employee = await requireEmployee(ctx.user.id);
+        return db.createEmergencyContact({
+          ...input,
+          employeeId: employee.id,
+          isPrimary: input.isPrimary ?? false,
+        });
+      }),
+
+    updateEmergencyContact: protectedProcedure
+      .input(
+        z.object({
+          id: z.number(),
+          name: z.string().optional(),
+          relationship: z.string().optional(),
+          phone: z.string().optional(),
+          email: z.string().email().optional().or(z.literal("")),
+          address: z.string().optional(),
+          isPrimary: z.boolean().optional(),
+        }),
+      )
+      .mutation(async ({ input, ctx }) => {
+        const employee = await requireEmployee(ctx.user.id);
+        const contacts = await db.getEmergencyContacts(employee.id);
+        if (!contacts.some((c) => c.id === input.id)) {
+          throw new TRPCError({ code: "FORBIDDEN", message: "Not your contact" });
+        }
+        const { id, ...data } = input;
+        await db.updateEmergencyContact(id, data);
+        return { success: true };
+      }),
+
+    deleteEmergencyContact: protectedProcedure
+      .input(z.object({ id: z.number() }))
+      .mutation(async ({ input, ctx }) => {
+        const employee = await requireEmployee(ctx.user.id);
+        const contacts = await db.getEmergencyContacts(employee.id);
+        if (!contacts.some((c) => c.id === input.id)) {
+          throw new TRPCError({ code: "FORBIDDEN", message: "Not your contact" });
+        }
+        await db.deleteEmergencyContact(input.id);
+        return { success: true };
+      }),
+
+    // ---- Pay ----
+    payslips: protectedProcedure.query(async ({ ctx }) => {
+      const employee = await requireEmployee(ctx.user.id);
+      return db.getEmployeePayments({ employeeId: employee.id });
+    }),
+
+    compensation: protectedProcedure.query(async ({ ctx }) => {
+      const employee = await requireEmployee(ctx.user.id);
+      return db.getCompensationHistory(employee.id);
+    }),
+
+    // ---- PTO balances ----
+    ptoBalances: protectedProcedure
+      .input(z.object({ year: z.number().optional() }).optional())
+      .query(async ({ input, ctx }) => {
+        const employee = await requireEmployee(ctx.user.id);
+        const year = input?.year ?? new Date().getFullYear();
+        return db.getPtoBalances(employee.id, year);
+      }),
+
+    // ---- Leave requests ----
+    leaveRequests: protectedProcedure.query(async ({ ctx }) => {
+      const employee = await requireEmployee(ctx.user.id);
+      return db.getLeaveRequests({ employeeId: employee.id });
+    }),
+
+    submitLeaveRequest: protectedProcedure
+      .input(
+        z.object({
+          leaveType: z.enum(LEAVE_TYPES),
+          startDate: z.date(),
+          endDate: z.date(),
+          hours: z.number().positive(),
+          reason: z.string().optional(),
+        }),
+      )
+      .mutation(async ({ input, ctx }) => {
+        if (input.endDate < input.startDate) {
+          throw new TRPCError({ code: "BAD_REQUEST", message: "End date is before start date" });
+        }
+        const employee = await requireEmployee(ctx.user.id);
+        const result = await db.createLeaveRequest({
+          employeeId: employee.id,
+          leaveType: input.leaveType,
+          startDate: input.startDate,
+          endDate: input.endDate,
+          hours: input.hours.toString(),
+          reason: input.reason,
+          status: "pending",
+        });
+        await db.adjustPtoBalance(
+          employee.id,
+          input.leaveType,
+          input.startDate.getFullYear(),
+          { pending: input.hours },
+        );
+        await createAuditLog(ctx.user.id, "create", "leave_request", result.id);
+        return result;
+      }),
+
+    cancelLeaveRequest: protectedProcedure
+      .input(z.object({ id: z.number() }))
+      .mutation(async ({ input, ctx }) => {
+        const employee = await requireEmployee(ctx.user.id);
+        const req = await db.getLeaveRequestById(input.id);
+        if (!req || req.employeeId !== employee.id) {
+          throw new TRPCError({ code: "FORBIDDEN", message: "Not your request" });
+        }
+        if (req.status === "cancelled" || req.status === "rejected") {
+          return { success: true };
+        }
+        await db.updateLeaveRequest(input.id, { status: "cancelled" });
+        if (req.status === "pending") {
+          await db.adjustPtoBalance(
+            employee.id,
+            req.leaveType,
+            new Date(req.startDate).getFullYear(),
+            { pending: -Number(req.hours) },
+          );
+        } else if (req.status === "approved") {
+          await db.adjustPtoBalance(
+            employee.id,
+            req.leaveType,
+            new Date(req.startDate).getFullYear(),
+            { used: -Number(req.hours) },
+          );
+        }
+        await createAuditLog(ctx.user.id, "update", "leave_request", input.id, "cancelled");
+        return { success: true };
+      }),
+
+    // Manager/admin action — approve/reject
+    decideLeaveRequest: protectedProcedure
+      .input(
+        z.object({
+          id: z.number(),
+          decision: z.enum(["approved", "rejected"]),
+          rejectionReason: z.string().optional(),
+        }),
+      )
+      .mutation(async ({ input, ctx }) => {
+        const req = await db.getLeaveRequestById(input.id);
+        if (!req) throw new TRPCError({ code: "NOT_FOUND", message: "Leave request not found" });
+        const target = await db.getEmployeeById(req.employeeId);
+        const isManager = target?.managerId && target.managerId === ctx.user.id;
+        if (!isManager && !["admin", "exec"].includes(ctx.user.role)) {
+          throw new TRPCError({ code: "FORBIDDEN", message: "Only managers/admins can decide" });
+        }
+        if (req.status !== "pending") {
+          throw new TRPCError({ code: "BAD_REQUEST", message: "Request already decided" });
+        }
+        await db.updateLeaveRequest(input.id, {
+          status: input.decision,
+          approverId: ctx.user.id,
+          approvedAt: new Date(),
+          rejectionReason: input.rejectionReason,
+        });
+        const year = new Date(req.startDate).getFullYear();
+        const hours = Number(req.hours);
+        if (input.decision === "approved") {
+          await db.adjustPtoBalance(req.employeeId, req.leaveType, year, {
+            pending: -hours,
+            used: hours,
+          });
+        } else {
+          await db.adjustPtoBalance(req.employeeId, req.leaveType, year, { pending: -hours });
+        }
+        await createAuditLog(ctx.user.id, input.decision === "approved" ? "approve" : "reject", "leave_request", input.id);
+        return { success: true };
+      }),
+
+    // ---- Onboarding ----
+    onboardingTasks: protectedProcedure.query(async ({ ctx }) => {
+      const employee = await requireEmployee(ctx.user.id);
+      return db.getOnboardingTasks(employee.id);
+    }),
+
+    updateOnboardingTask: protectedProcedure
+      .input(
+        z.object({
+          id: z.number(),
+          status: z.enum(ONBOARDING_STATUSES).optional(),
+        }),
+      )
+      .mutation(async ({ input, ctx }) => {
+        const employee = await requireEmployee(ctx.user.id);
+        const tasks = await db.getOnboardingTasks(employee.id);
+        const task = tasks.find((t) => t.id === input.id);
+        if (!task) throw new TRPCError({ code: "FORBIDDEN", message: "Not your task" });
+        await db.updateOnboardingTask(input.id, {
+          status: input.status,
+          completedAt: input.status === "completed" ? new Date() : null,
+        });
+        return { success: true };
+      }),
+
+    // Admin/HR-only: create a task for an employee
+    createOnboardingTask: protectedProcedure
+      .input(
+        z.object({
+          employeeId: z.number(),
+          title: z.string().min(1),
+          description: z.string().optional(),
+          category: z.enum(ONBOARDING_CATEGORIES).optional(),
+          dueDate: z.date().optional(),
+          sortOrder: z.number().optional(),
+        }),
+      )
+      .mutation(async ({ input, ctx }) => {
+        if (!["admin", "exec"].includes(ctx.user.role)) {
+          throw new TRPCError({ code: "FORBIDDEN", message: "Admin only" });
+        }
+        const result = await db.createOnboardingTask({
+          ...input,
+          createdBy: ctx.user.id,
+          status: "pending",
+        });
+        await createAuditLog(ctx.user.id, "create", "onboarding_task", result.id, input.title);
+        return result;
+      }),
+
+    // ---- Benefits ----
+    benefits: protectedProcedure.query(async ({ ctx }) => {
+      const employee = await requireEmployee(ctx.user.id);
+      return db.getEmployeeBenefits(employee.id);
+    }),
+
+    upsertBenefitElection: protectedProcedure
+      .input(
+        z.object({
+          benefitType: z.enum(BENEFIT_TYPES),
+          plan: z.string().optional(),
+          carrier: z.string().optional(),
+          coverageLevel: z.enum(COVERAGE_LEVELS).optional(),
+          employeeContribution: z.string().optional(),
+          employerContribution: z.string().optional(),
+          enrollmentStatus: z.enum(ENROLLMENT_STATUSES).optional(),
+          effectiveDate: z.date().optional(),
+          notes: z.string().optional(),
+        }),
+      )
+      .mutation(async ({ input, ctx }) => {
+        const employee = await requireEmployee(ctx.user.id);
+        const result = await db.upsertEmployeeBenefit({
+          ...input,
+          employeeId: employee.id,
+          enrollmentStatus: input.enrollmentStatus ?? "pending",
+        });
+        await createAuditLog(ctx.user.id, "update", "employee_benefit", result.id, input.benefitType);
+        return result;
+      }),
+
+    // ---- Documents ----
+    documents: protectedProcedure.query(async ({ ctx }) => {
+      const employee = await requireEmployee(ctx.user.id);
+      return db.getDocuments({ referenceType: "employee", referenceId: employee.id });
+    }),
+
+    // ---- Directory ----
+    directory: protectedProcedure.query(async () => {
+      const list = await db.getEmployees({ status: "active" });
+      return list.map((e) => ({
+        id: e.id,
+        firstName: e.firstName,
+        lastName: e.lastName,
+        jobTitle: e.jobTitle,
+        email: e.email,
+        phone: e.phone,
+        departmentId: e.departmentId,
+      }));
+    }),
+
+    // ---- Team (for managers) ----
+    myTeam: protectedProcedure.query(async ({ ctx }) => {
+      const all = await db.getEmployees();
+      const reports = all.filter((e) => e.managerId === ctx.user.id);
+      const pending = await db.getLeaveRequests({ status: "pending" });
+      const reportIds = new Set(reports.map((r) => r.id));
+      return {
+        reports,
+        pendingLeaveRequests: pending.filter((r) => reportIds.has(r.employeeId)),
+      };
+    }),
+});
+
+// Export helpers so tests can reach them
+export { canViewEmployee };

--- a/server/routers/index.ts
+++ b/server/routers/index.ts
@@ -14,6 +14,7 @@ import { freightRouter } from "./freight";
 import { ediRouter } from "./edi";
 import { emailRouter } from "./email";
 import { hrRouter } from "./hr";
+import { employeePortalRouter } from "./employeePortal";
 import { legalRouter } from "./legal";
 import { projectsRouter } from "./projects";
 import { dataRoomRouter } from "./dataRoom";
@@ -31,6 +32,9 @@ const baseRouter = router({
 
   // Reasoning Agent
   agent: agentRouter,
+
+  // Employee self-service portal
+  employeePortal: employeePortalRouter,
 });
 
 export const appRouter = mergeRouters(


### PR DESCRIPTION
## Summary
Implements a comprehensive employee self-service portal that allows employees to view and manage their HR information, including profile details, compensation, time off, benefits, onboarding tasks, documents, and emergency contacts.

## Key Changes

### Frontend
- **New EmployeePortal component** (`client/src/pages/hr/EmployeePortal.tsx`): A 1,174-line React component with 8 tabs providing:
  - Profile management (editable contact information)
  - Pay history and compensation details
  - PTO balance tracking and leave request submission
  - Onboarding task progress
  - Benefits enrollment status
  - Document access
  - Company directory
  - Emergency contact management
- Updated `HRHub.tsx` to include portal navigation
- Added route in `App.tsx` for `/hr/me` employee portal page
- Added "View Portal" button in Employees list for quick access

### Backend
- **New employeePortal router** (`server/routers/employeePortal.ts`): 404-line TRPC router with procedures for:
  - Profile queries and updates
  - Emergency contact CRUD operations
  - Payslip and compensation history retrieval
  - PTO balance queries and adjustments
  - Leave request submission and cancellation
  - Onboarding task management
  - Benefits enrollment queries
  - Document and directory access
- **Database functions** in `server/db.ts` and `server/db/hr.ts`:
  - PTO balance management (upsert, adjust, query)
  - Leave request CRUD operations
  - Emergency contact management
  - Onboarding task operations
  - Benefits enrollment queries
  - Employee lookup by user ID

### Database
- **Migration 0032** (`drizzle/0032_employee_portal.sql`): Adds 5 new tables:
  - `pto_balances`: Track accrued, used, pending, and carry-over hours per employee/leave-type/year
  - `leave_requests`: Store leave request submissions with approval workflow
  - `onboarding_tasks`: Track onboarding checklist items
  - `employee_benefits`: Benefits enrollment with coverage levels and status
  - `employee_emergency_contacts`: Emergency contact information
- Enhanced `employee_payments` table with payslip details (gross amount, tax withheld, deductions, payslip URL)
- Updated schema in `drizzle/schema.ts` with new table definitions

### Testing
- Added comprehensive test suite (`server/employeePortal.test.ts`) covering:
  - Profile queries
  - Leave request submission and validation
  - Leave request cancellation with PTO refunds
  - Permission checks for self-service operations

## Implementation Details
- Uses TRPC for type-safe client-server communication
- Implements role-based access control ensuring employees can only access their own data
- Includes validation for date ranges, hours, and required fields
- Automatically adjusts PTO balances when leave requests are submitted/cancelled
- Supports multiple leave types (vacation, sick, personal, parental, bereavement, unpaid, other)
- Provides formatted currency and date display utilities
- Includes audit logging for profile updates and leave requests

https://claude.ai/code/session_01Rssa3XR17miZkqmKpMwkkx

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an employee self‑service HR portal at `/hr/me` so employees can manage their own profile, pay, time off, benefits, onboarding, documents, directory, and emergency contacts. Uses transactional helpers for leave requests to keep PTO balances and request status in sync, plus small fixes to routing and forms.

- **New Features**
  - New portal at `/hr/me` with 8 tabs (Profile, Pay, Time Off, Onboarding, Benefits, Documents, Directory, Emergency).
  - HR landing routes non‑managers to the portal; managers/admins/finance keep the team view. Added “My Portal” button in Employees and gated HRHub on auth loading to prevent flicker.
  - Full leave request flow (submit, cancel, approve/reject) using transactional helpers for atomic pending/used PTO adjustments with audit logs.
  - Backend `employeePortal` router with role/ownership checks for payslips/compensation, benefit elections, profile updates, documents, onboarding tasks, directory, and manager approvals.
  - Fixes: local‑time PTO date parsing to avoid off‑by‑one in western timezones; hardened helpers to prevent duplicate benefit elections and missing PTO balance records; Profile tab fields sync on data changes and delete button has an aria‑label.

- **Migration**
  - New tables: `pto_balances`, `leave_requests`, `onboarding_tasks`, `employee_benefits`, `employee_emergency_contacts` with FKs to `employees` and `users`.
  - Extended `employee_payments` with `grossAmount`, `taxWithheld`, `otherDeductions`, `payslipUrl` (migration 0032); added indexes on `employeeId` for the new tables and on `leave_requests.status` for faster queries.

<sup>Written for commit aa719189e71ecec888c360c1e42c8dde660f3dec. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

