### PR TITLE
Add Remotion skill documentation for video composition

### DIFF
--- a/.claude/skills/remotion/SKILL.md
+++ b/.claude/skills/remotion/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: remotion
+description: Use when creating, editing, or rendering programmatic videos with Remotion (React-based video framework). Triggers on requests involving <Composition>, useCurrentFrame, video rendering, or .tsx files in remotion/ directories.
+---
+
+# Remotion
+
+## When to use
+- User wants to build/edit a Remotion video composition
+- Working with files under `remotion/` or `src/remotion/`
+- Rendering videos via `npx remotion render` or `@remotion/renderer`
+
+## Setup
+- `npm i remotion @remotion/cli @remotion/player`
+- Entry: `src/index.ts` calling `registerRoot(RemotionRoot)`
+- Compositions defined with `<Composition id="..." component={...} durationInFrames={...} fps={30} width={1920} height={1080} />`
+
+## Key APIs
+- `useCurrentFrame()` — current frame number
+- `useVideoConfig()` — { fps, width, height, durationInFrames }
+- `interpolate(frame, [0, 30], [0, 1])` for animations
+- `spring({ frame, fps })` for physics-based motion
+- `<Sequence from={30} durationInFrames={60}>` to time-shift children
+
+## Rendering
+- Preview: `npx remotion studio`
+- Render: `npx remotion render src/index.ts CompId out/video.mp4`
+
+## Gotchas
+- All animation must be deterministic per frame — no timers, no random without seed
+- Assets must be in `public/` and referenced via `staticFile()`
+- Don't use `setTimeout`/`setInterval` — use frame math instead


### PR DESCRIPTION
## Summary
Added skill documentation for Remotion, a React-based video framework, to guide AI assistants in helping users create and render programmatic videos.

## Changes
- Created `.claude/skills/remotion/SKILL.md` with comprehensive Remotion skill definition
  - Documented when to trigger the skill (Composition components, useCurrentFrame, video rendering, remotion/ directories)
  - Included setup instructions (npm packages, entry point configuration)
  - Listed key APIs (useCurrentFrame, useVideoConfig, interpolate, spring, Sequence)
  - Provided rendering commands (studio preview and CLI render)
  - Highlighted important gotchas (deterministic animations, asset handling, avoiding timers)

## Details
This skill file enables Claude to recognize Remotion-related requests and provide contextual assistance with:
- Building and editing video compositions
- Working with frame-based animations and timing
- Rendering videos via CLI or programmatic APIs
- Avoiding common pitfalls like non-deterministic code and improper asset references

https://claude.ai/code/session_01HXsoGhHDXTuQCshF5HCQ8U

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Remotion skill documentation to support building and rendering programmatic videos with Remotion. Provides clear triggers, setup, key APIs, and render commands so related requests are handled correctly.

- **New Features**
  - Added `.claude/skills/remotion/SKILL.md` with when-to-trigger guidance (compositions, `useCurrentFrame`, CLI render, `remotion/` dirs).
  - Setup: install `remotion`, `@remotion/cli`, `@remotion/player`; register root and define `<Composition>`.
  - API quick reference: `useCurrentFrame`, `useVideoConfig`, `interpolate`, `spring`, `Sequence`.
  - Rendering and gotchas: `npx remotion studio`/`render`, deterministic frame logic, assets via `staticFile()`, avoid timers.

<sup>Written for commit c07a5041fa3911f8050d69be5de242f5aef6194c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

