### PR TITLE
Add recipe sharing with copackers via portal

### DIFF
--- a/client/src/pages/operations/Recipes.tsx
+++ b/client/src/pages/operations/Recipes.tsx
@@ -8,7 +8,8 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Badge } from "@/components/ui/badge";
-import { Calculator, Link2, Plus } from "lucide-react";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Calculator, Link2, Plus, Share2, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 
 export default function Recipes() {
@@ -73,6 +74,37 @@ export default function Recipes() {
   );
 
   const [syncProductId, setSyncProductId] = useState<string>("");
+
+  // --- Copacker sharing ---
+  const [shareRecipeId, setShareRecipeId] = useState<number | null>(null);
+  const { data: copackerWarehouses } = trpc.warehouses.list.useQuery({ type: "copacker" });
+  const {
+    data: shares,
+    refetch: refetchShares,
+  } = trpc.recipes.listShares.useQuery(
+    { recipeId: shareRecipeId! },
+    { enabled: !!shareRecipeId },
+  );
+  const shareRecipe = trpc.recipes.share.useMutation({
+    onSuccess: () => { toast.success("Share updated"); refetchShares(); },
+    onError: (err) => toast.error(err.message),
+  });
+  const unshareRecipe = trpc.recipes.unshare.useMutation({
+    onSuccess: () => { toast.success("Share removed"); refetchShares(); },
+    onError: (err) => toast.error(err.message),
+  });
+  const shareRecipeName = useMemo(
+    () => recipes?.find((r) => r.id === shareRecipeId)?.name ?? "",
+    [recipes, shareRecipeId],
+  );
+  const shareByWarehouse = useMemo(() => {
+    const m = new Map<number, { shareIngredients: boolean; shareProcedures: boolean }>();
+    (shares ?? []).forEach((s: any) => m.set(s.warehouseId, {
+      shareIngredients: !!s.shareIngredients,
+      shareProcedures: !!s.shareProcedures,
+    }));
+    return m;
+  }, [shares]);
 
   return (
     <div className="p-6 space-y-6">
@@ -200,6 +232,10 @@ export default function Recipes() {
                       <Calculator className="h-4 w-4 mr-1" />
                       Cost
                     </Button>
+                    <Button variant="ghost" size="sm" onClick={() => setShareRecipeId(recipe.id)}>
+                      <Share2 className="h-4 w-4 mr-1" />
+                      Share
+                    </Button>
                   </TableCell>
                 </TableRow>
               )) : (
@@ -209,6 +245,113 @@ export default function Recipes() {
           </Table>
         </CardContent>
       </Card>
+
+      <Dialog open={shareRecipeId != null} onOpenChange={(open) => !open && setShareRecipeId(null)}>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>Share recipe with copackers</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-3 pt-2">
+            <p className="text-sm text-muted-foreground">
+              Choose which copacker facilities can see <span className="font-medium">{shareRecipeName}</span>{" "}
+              in their portal. Toggle which parts (ingredients, procedures) each copacker receives.
+            </p>
+            {!copackerWarehouses?.length ? (
+              <p className="text-sm text-muted-foreground">
+                No copacker locations configured. Add a warehouse with type "copacker" first.
+              </p>
+            ) : (
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Copacker</TableHead>
+                    <TableHead className="text-center">Ingredients</TableHead>
+                    <TableHead className="text-center">Procedures</TableHead>
+                    <TableHead className="text-right">Action</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {copackerWarehouses.map((wh: any) => {
+                    const current = shareByWarehouse.get(wh.id);
+                    const isShared = !!current;
+                    return (
+                      <TableRow key={wh.id}>
+                        <TableCell>
+                          <div className="font-medium text-sm">{wh.name}</div>
+                          {wh.code ? <div className="text-xs text-muted-foreground font-mono">{wh.code}</div> : null}
+                        </TableCell>
+                        <TableCell className="text-center">
+                          <Checkbox
+                            checked={current?.shareIngredients ?? true}
+                            disabled={!isShared || shareRecipe.isPending}
+                            onCheckedChange={(v) => {
+                              if (!shareRecipeId) return;
+                              shareRecipe.mutate({
+                                recipeId: shareRecipeId,
+                                warehouseId: wh.id,
+                                shareIngredients: !!v,
+                                shareProcedures: current?.shareProcedures ?? true,
+                              });
+                            }}
+                          />
+                        </TableCell>
+                        <TableCell className="text-center">
+                          <Checkbox
+                            checked={current?.shareProcedures ?? true}
+                            disabled={!isShared || shareRecipe.isPending}
+                            onCheckedChange={(v) => {
+                              if (!shareRecipeId) return;
+                              shareRecipe.mutate({
+                                recipeId: shareRecipeId,
+                                warehouseId: wh.id,
+                                shareIngredients: current?.shareIngredients ?? true,
+                                shareProcedures: !!v,
+                              });
+                            }}
+                          />
+                        </TableCell>
+                        <TableCell className="text-right">
+                          {isShared ? (
+                            <Button
+                              size="sm"
+                              variant="ghost"
+                              disabled={unshareRecipe.isPending}
+                              onClick={() => {
+                                if (!shareRecipeId) return;
+                                unshareRecipe.mutate({ recipeId: shareRecipeId, warehouseId: wh.id });
+                              }}
+                            >
+                              <Trash2 className="h-4 w-4 mr-1" />
+                              Unshare
+                            </Button>
+                          ) : (
+                            <Button
+                              size="sm"
+                              disabled={shareRecipe.isPending}
+                              onClick={() => {
+                                if (!shareRecipeId) return;
+                                shareRecipe.mutate({
+                                  recipeId: shareRecipeId,
+                                  warehouseId: wh.id,
+                                  shareIngredients: true,
+                                  shareProcedures: true,
+                                });
+                              }}
+                            >
+                              <Share2 className="h-4 w-4 mr-1" />
+                              Share
+                            </Button>
+                          )}
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })}
+                </TableBody>
+              </Table>
+            )}
+          </div>
+        </DialogContent>
+      </Dialog>
 
       {selectedRecipeId && selectedRecipe && (
         <Card>

--- a/client/src/pages/operations/Recipes.tsx
+++ b/client/src/pages/operations/Recipes.tsx
@@ -86,11 +86,11 @@ export default function Recipes() {
     { enabled: !!shareRecipeId },
   );
   const shareRecipe = trpc.recipes.share.useMutation({
-    onSuccess: () => { toast.success("Share updated"); refetchShares(); },
+    onSuccess: (_, variables) => { toast.success("Share updated"); if (shareRecipeId === variables.recipeId) refetchShares(); },
     onError: (err) => toast.error(err.message),
   });
   const unshareRecipe = trpc.recipes.unshare.useMutation({
-    onSuccess: () => { toast.success("Share removed"); refetchShares(); },
+    onSuccess: (_, variables) => { toast.success("Share removed"); if (shareRecipeId === variables.recipeId) refetchShares(); },
     onError: (err) => toast.error(err.message),
   });
   const shareRecipeName = useMemo(

--- a/client/src/pages/portal/CopackerPortal.tsx
+++ b/client/src/pages/portal/CopackerPortal.tsx
@@ -869,7 +869,14 @@ export default function CopackerPortal() {
       </Card>
 
       {/* Shared Recipe Detail Dialog */}
-      <Dialog open={!!viewSharedRecipeId} onOpenChange={() => setViewSharedRecipeId(null)}>
+      <Dialog
+        open={!!viewSharedRecipeId}
+        onOpenChange={(open) => {
+          if (!open) {
+            setViewSharedRecipeId(null);
+          }
+        }}
+      >
         <DialogContent className="max-w-3xl max-h-[85vh] overflow-y-auto">
           <DialogHeader>
             <DialogTitle>

--- a/client/src/pages/portal/CopackerPortal.tsx
+++ b/client/src/pages/portal/CopackerPortal.tsx
@@ -117,6 +117,7 @@ export default function CopackerPortal() {
   // --- Detail view ---
   const [viewUpdateId, setViewUpdateId] = useState<number | null>(null);
   const [viewInvoiceId, setViewInvoiceId] = useState<number | null>(null);
+  const [viewSharedRecipeId, setViewSharedRecipeId] = useState<number | null>(null);
 
   // ---- Queries ----
   const { data: warehouse } = trpc.copackerPortal.getWarehouse.useQuery();
@@ -126,6 +127,11 @@ export default function CopackerPortal() {
   const { data: inventoryUpdates, refetch: refetchUpdates } = (trpc.copackerPortal as any).getInventoryUpdates.useQuery();
   const { data: invoices, refetch: refetchInvoices } = (trpc.copackerPortal as any).getInvoices.useQuery();
   const { data: shippingDocs, refetch: refetchShipDocs } = (trpc.copackerPortal as any).getShippingDocuments.useQuery();
+  const { data: sharedRecipes } = (trpc.copackerPortal as any).getSharedRecipes.useQuery();
+  const { data: sharedRecipeDetail } = (trpc.copackerPortal as any).getSharedRecipeDetail.useQuery(
+    { recipeId: viewSharedRecipeId! },
+    { enabled: !!viewSharedRecipeId }
+  );
   const { data: updateDetail } = (trpc.copackerPortal as any).getInventoryUpdateDetail.useQuery(
     { id: viewUpdateId! },
     { enabled: !!viewUpdateId }
@@ -791,6 +797,189 @@ export default function CopackerPortal() {
           )}
         </CardContent>
       </Card>
+
+      {/* Shared Recipes */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <div>
+              <CardTitle>Shared Recipes</CardTitle>
+              <CardDescription>
+                Recipes and production procedures shared with your facility
+              </CardDescription>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {!sharedRecipes?.length ? (
+            <div className="text-center py-6 text-muted-foreground">
+              No recipes have been shared with your facility yet
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Recipe ID</TableHead>
+                  <TableHead>Name</TableHead>
+                  <TableHead>Category</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead className="text-right">Batch (g)</TableHead>
+                  <TableHead className="text-right">Yield %</TableHead>
+                  <TableHead>Includes</TableHead>
+                  <TableHead className="text-right">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {sharedRecipes.map((r: any) => (
+                  <TableRow key={r.id}>
+                    <TableCell className="font-mono text-xs">{r.recipeId}</TableCell>
+                    <TableCell className="font-medium">{r.name}</TableCell>
+                    <TableCell className="capitalize">{r.category}</TableCell>
+                    <TableCell>
+                      <Badge variant="outline" className="capitalize">{r.status}</Badge>
+                    </TableCell>
+                    <TableCell className="text-right font-mono text-sm">
+                      {parseFloat(r.baseBatchGrams?.toString() ?? "0").toLocaleString()}
+                    </TableCell>
+                    <TableCell className="text-right font-mono text-sm">
+                      {(parseFloat(r.expectedYieldPct?.toString() ?? "0") * 100).toFixed(1)}%
+                    </TableCell>
+                    <TableCell className="text-xs text-muted-foreground">
+                      {[r.shareIngredients ? "Ingredients" : null, r.shareProcedures ? "Procedures" : null]
+                        .filter(Boolean)
+                        .join(" + ") || "—"}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        className="h-7 text-xs"
+                        onClick={() => setViewSharedRecipeId(r.id)}
+                      >
+                        <Eye className="h-3 w-3 mr-1" />
+                        View
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Shared Recipe Detail Dialog */}
+      <Dialog open={!!viewSharedRecipeId} onOpenChange={() => setViewSharedRecipeId(null)}>
+        <DialogContent className="max-w-3xl max-h-[85vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>
+              {sharedRecipeDetail?.recipe?.name ?? "Recipe"}
+            </DialogTitle>
+            <DialogDescription>
+              {sharedRecipeDetail?.recipe?.recipeId
+                ? `Recipe ${sharedRecipeDetail.recipe.recipeId} · v${sharedRecipeDetail.recipe.version}`
+                : ""}
+            </DialogDescription>
+          </DialogHeader>
+          {sharedRecipeDetail ? (
+            <div className="space-y-4 text-sm">
+              <div className="grid grid-cols-3 gap-3">
+                <div>
+                  <div className="text-muted-foreground text-xs">Category</div>
+                  <div className="font-medium capitalize">{sharedRecipeDetail.recipe.category}</div>
+                </div>
+                <div>
+                  <div className="text-muted-foreground text-xs">Base batch (g)</div>
+                  <div className="font-medium font-mono">
+                    {parseFloat(sharedRecipeDetail.recipe.baseBatchGrams?.toString() ?? "0").toLocaleString()}
+                  </div>
+                </div>
+                <div>
+                  <div className="text-muted-foreground text-xs">Expected yield</div>
+                  <div className="font-medium font-mono">
+                    {(parseFloat(sharedRecipeDetail.recipe.expectedYieldPct?.toString() ?? "0") * 100).toFixed(1)}%
+                  </div>
+                </div>
+              </div>
+
+              {sharedRecipeDetail.share?.notes ? (
+                <Alert>
+                  <AlertTitle>Notes from operations</AlertTitle>
+                  <AlertDescription>{sharedRecipeDetail.share.notes}</AlertDescription>
+                </Alert>
+              ) : null}
+
+              {sharedRecipeDetail.shareIngredients ? (
+                <div>
+                  <div className="font-medium mb-2">Ingredients</div>
+                  {sharedRecipeDetail.lines?.length ? (
+                    <Table>
+                      <TableHeader>
+                        <TableRow>
+                          <TableHead>#</TableHead>
+                          <TableHead>Ingredient / Sub-recipe</TableHead>
+                          <TableHead className="text-right">Wet (g)</TableHead>
+                          <TableHead className="text-right">Dry (g)</TableHead>
+                        </TableRow>
+                      </TableHeader>
+                      <TableBody>
+                        {sharedRecipeDetail.lines.map((line: any) => (
+                          <TableRow key={line.id}>
+                            <TableCell>{line.lineNumber}</TableCell>
+                            <TableCell>
+                              {line.subRecipeId
+                                ? <Badge variant="secondary">Sub-recipe #{line.subRecipeId}</Badge>
+                                : <span>Ingredient #{line.ingredientId}</span>}
+                            </TableCell>
+                            <TableCell className="text-right font-mono">{line.quantityGrams}</TableCell>
+                            <TableCell className="text-right font-mono">{line.quantityGramsDry ?? "—"}</TableCell>
+                          </TableRow>
+                        ))}
+                      </TableBody>
+                    </Table>
+                  ) : (
+                    <div className="text-muted-foreground text-xs">No ingredient lines defined</div>
+                  )}
+                </div>
+              ) : (
+                <div className="text-xs text-muted-foreground italic">
+                  Ingredients are withheld for this share.
+                </div>
+              )}
+
+              {sharedRecipeDetail.shareProcedures ? (
+                <div>
+                  <div className="font-medium mb-2">Procedures</div>
+                  {sharedRecipeDetail.procedures?.length ? (
+                    <ol className="space-y-2 list-decimal list-inside">
+                      {sharedRecipeDetail.procedures.map((p: any) => (
+                        <li key={p.id}>
+                          <span>{p.instruction}</span>
+                          {(p.durationMinutes || p.temperatureF) ? (
+                            <span className="text-muted-foreground ml-2 text-xs">
+                              {p.durationMinutes ? `${p.durationMinutes} min` : ""}
+                              {p.durationMinutes && p.temperatureF ? " · " : ""}
+                              {p.temperatureF ? `${p.temperatureF}°F` : ""}
+                            </span>
+                          ) : null}
+                        </li>
+                      ))}
+                    </ol>
+                  ) : (
+                    <div className="text-muted-foreground text-xs">No procedure steps defined</div>
+                  )}
+                </div>
+              ) : (
+                <div className="text-xs text-muted-foreground italic">
+                  Procedures are withheld for this share.
+                </div>
+              )}
+            </div>
+          ) : (
+            <div className="text-sm text-muted-foreground py-6 text-center">Loading…</div>
+          )}
+        </DialogContent>
+      </Dialog>
 
       {/* ============ DIALOGS ============ */}
 

--- a/drizzle/0033_recipe_copacker_shares.sql
+++ b/drizzle/0033_recipe_copacker_shares.sql
@@ -1,0 +1,32 @@
+-- Migration 0033: Per-copacker recipe sharing.
+-- A recipe is visible in a copacker's portal only if a row exists here for
+-- their linked warehouse. Toggles control whether ingredients and/or
+-- procedures are shared.
+
+CREATE TABLE IF NOT EXISTS `recipe_copacker_shares` (
+  `id` int AUTO_INCREMENT NOT NULL,
+  `recipeId` int NOT NULL,
+  `warehouseId` int NOT NULL,
+  `shareIngredients` boolean NOT NULL DEFAULT true,
+  `shareProcedures` boolean NOT NULL DEFAULT true,
+  `notes` text,
+  `sharedBy` int,
+  `sharedAt` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT `recipe_copacker_shares_id` PRIMARY KEY(`id`),
+  CONSTRAINT `recipe_copacker_shares_recipe_warehouse_idx` UNIQUE(`recipeId`,`warehouseId`)
+);
+--> statement-breakpoint
+
+ALTER TABLE `recipe_copacker_shares`
+  ADD CONSTRAINT `recipe_copacker_shares_recipe_fk`
+  FOREIGN KEY (`recipeId`) REFERENCES `recipes`(`id`);
+--> statement-breakpoint
+
+ALTER TABLE `recipe_copacker_shares`
+  ADD CONSTRAINT `recipe_copacker_shares_warehouse_fk`
+  FOREIGN KEY (`warehouseId`) REFERENCES `warehouses`(`id`);
+--> statement-breakpoint
+
+ALTER TABLE `recipe_copacker_shares`
+  ADD CONSTRAINT `recipe_copacker_shares_sharedBy_fk`
+  FOREIGN KEY (`sharedBy`) REFERENCES `users`(`id`);

--- a/drizzle/0033_recipe_copacker_shares.sql
+++ b/drizzle/0033_recipe_copacker_shares.sql
@@ -13,7 +13,8 @@ CREATE TABLE IF NOT EXISTS `recipe_copacker_shares` (
   `sharedBy` int,
   `sharedAt` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   CONSTRAINT `recipe_copacker_shares_id` PRIMARY KEY(`id`),
-  CONSTRAINT `recipe_copacker_shares_recipe_warehouse_idx` UNIQUE(`recipeId`,`warehouseId`)
+  CONSTRAINT `recipe_copacker_shares_recipe_warehouse_idx` UNIQUE(`recipeId`,`warehouseId`),
+  KEY `recipe_copacker_shares_warehouse_sharedAt_idx` (`warehouseId`,`sharedAt`)
 );
 --> statement-breakpoint
 

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -225,6 +225,20 @@
       "when": 1776200000000,
       "tag": "0031_recipe_bom_link",
       "breakpoints": true
+    },
+    {
+      "idx": 32,
+      "version": "5",
+      "when": 1776300000000,
+      "tag": "0032_employee_portal",
+      "breakpoints": true
+    },
+    {
+      "idx": 33,
+      "version": "5",
+      "when": 1776400000000,
+      "tag": "0033_recipe_copacker_shares",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -1872,6 +1872,24 @@ export type InsertBatchCostSnapshot = typeof batchCostSnapshots.$inferInsert;
 export type BomVersionHistory = typeof bomVersionHistory.$inferSelect;
 export type InsertBomVersionHistory = typeof bomVersionHistory.$inferInsert;
 
+// Per-copacker recipe sharing. A recipe is visible in a copacker's portal only
+// if a row exists here for their linked warehouse.
+export const recipeCopackerShares = mysqlTable("recipe_copacker_shares", {
+  id: int("id").autoincrement().primaryKey(),
+  recipeId: int("recipeId").notNull().references(() => recipes.id),
+  warehouseId: int("warehouseId").notNull().references(() => warehouses.id),
+  shareIngredients: boolean("shareIngredients").default(true).notNull(),
+  shareProcedures: boolean("shareProcedures").default(true).notNull(),
+  notes: text("notes"),
+  sharedBy: int("sharedBy").references(() => users.id),
+  sharedAt: timestamp("sharedAt").defaultNow().notNull(),
+}, (table) => ({
+  recipeWarehouseIdx: uniqueIndex("recipe_copacker_shares_recipe_warehouse_idx").on(table.recipeId, table.warehouseId),
+}));
+
+export type RecipeCopackerShare = typeof recipeCopackerShares.$inferSelect;
+export type InsertRecipeCopackerShare = typeof recipeCopackerShares.$inferInsert;
+
 // ============================================
 // COPACKER PORTAL
 // ============================================

--- a/server/db/manufacturing.ts
+++ b/server/db/manufacturing.ts
@@ -16,7 +16,8 @@ import {
   ingredientVendors, InsertIngredientVendor,
   ingredientQuoteRequests, InsertIngredientQuoteRequest,
   ingredientCostAlerts, InsertIngredientCostAlert,
-  vendors,
+  recipeCopackerShares, InsertRecipeCopackerShare,
+  vendors, warehouses,
 } from "../../drizzle/schema";
 import { getDb } from "./connection";
 
@@ -1082,6 +1083,122 @@ export async function createRecipeProcedure(data: Omit<InsertRecipeProcedure, "i
   if (!db) throw new Error("Database not available");
   const result = await db.insert(recipeProcedures).values(data).$returningId();
   return { id: result[0].id };
+}
+
+// ---- Recipe ↔ copacker sharing ------------------------------------------
+
+export async function getRecipeShares(recipeId: number) {
+  const db = await getDb();
+  if (!db) return [];
+  return db
+    .select({
+      id: recipeCopackerShares.id,
+      recipeId: recipeCopackerShares.recipeId,
+      warehouseId: recipeCopackerShares.warehouseId,
+      warehouseName: warehouses.name,
+      warehouseCode: warehouses.code,
+      shareIngredients: recipeCopackerShares.shareIngredients,
+      shareProcedures: recipeCopackerShares.shareProcedures,
+      notes: recipeCopackerShares.notes,
+      sharedBy: recipeCopackerShares.sharedBy,
+      sharedAt: recipeCopackerShares.sharedAt,
+    })
+    .from(recipeCopackerShares)
+    .innerJoin(warehouses, eq(warehouses.id, recipeCopackerShares.warehouseId))
+    .where(eq(recipeCopackerShares.recipeId, recipeId))
+    .orderBy(warehouses.name);
+}
+
+export async function upsertRecipeShare(data: {
+  recipeId: number;
+  warehouseId: number;
+  shareIngredients?: boolean;
+  shareProcedures?: boolean;
+  notes?: string | null;
+  sharedBy?: number;
+}) {
+  const db = await getDb();
+  if (!db) throw new Error("Database not available");
+  const existing = await db
+    .select()
+    .from(recipeCopackerShares)
+    .where(and(
+      eq(recipeCopackerShares.recipeId, data.recipeId),
+      eq(recipeCopackerShares.warehouseId, data.warehouseId),
+    ))
+    .limit(1);
+  if (existing.length > 0) {
+    await db
+      .update(recipeCopackerShares)
+      .set({
+        shareIngredients: data.shareIngredients ?? existing[0].shareIngredients,
+        shareProcedures: data.shareProcedures ?? existing[0].shareProcedures,
+        notes: data.notes === undefined ? existing[0].notes : data.notes,
+        sharedBy: data.sharedBy ?? existing[0].sharedBy,
+      })
+      .where(eq(recipeCopackerShares.id, existing[0].id));
+    return { id: existing[0].id, created: false };
+  }
+  const payload: InsertRecipeCopackerShare = {
+    recipeId: data.recipeId,
+    warehouseId: data.warehouseId,
+    shareIngredients: data.shareIngredients ?? true,
+    shareProcedures: data.shareProcedures ?? true,
+    notes: data.notes ?? null,
+    sharedBy: data.sharedBy ?? null,
+  };
+  const result = await db.insert(recipeCopackerShares).values(payload).$returningId();
+  return { id: result[0].id, created: true };
+}
+
+export async function removeRecipeShare(recipeId: number, warehouseId: number) {
+  const db = await getDb();
+  if (!db) throw new Error("Database not available");
+  await db
+    .delete(recipeCopackerShares)
+    .where(and(
+      eq(recipeCopackerShares.recipeId, recipeId),
+      eq(recipeCopackerShares.warehouseId, warehouseId),
+    ));
+}
+
+export async function getRecipesSharedWithWarehouse(warehouseId: number) {
+  const db = await getDb();
+  if (!db) return [];
+  return db
+    .select({
+      shareId: recipeCopackerShares.id,
+      shareIngredients: recipeCopackerShares.shareIngredients,
+      shareProcedures: recipeCopackerShares.shareProcedures,
+      notes: recipeCopackerShares.notes,
+      sharedAt: recipeCopackerShares.sharedAt,
+      id: recipes.id,
+      recipeId: recipes.recipeId,
+      name: recipes.name,
+      category: recipes.category,
+      status: recipes.status,
+      version: recipes.version,
+      baseBatchGrams: recipes.baseBatchGrams,
+      expectedYieldPct: recipes.expectedYieldPct,
+    })
+    .from(recipeCopackerShares)
+    .innerJoin(recipes, eq(recipes.id, recipeCopackerShares.recipeId))
+    .where(eq(recipeCopackerShares.warehouseId, warehouseId))
+    .orderBy(desc(recipeCopackerShares.sharedAt));
+}
+
+export async function getRecipeShareForWarehouse(recipeId: number, warehouseId: number) {
+  const db = await getDb();
+  if (!db) return undefined;
+  const result = await db
+    .select()
+    .from(recipeCopackerShares)
+    .where(and(
+      eq(recipeCopackerShares.recipeId, recipeId),
+      eq(recipeCopackerShares.warehouseId, warehouseId),
+    ))
+    .limit(1);
+  return result[0];
 }
 
 export async function calculateRecipeBatchCost(input: {

--- a/server/db/manufacturing.ts
+++ b/server/db/manufacturing.ts
@@ -1135,6 +1135,7 @@ export async function upsertRecipeShare(data: {
         shareProcedures: data.shareProcedures ?? existing[0].shareProcedures,
         notes: data.notes === undefined ? existing[0].notes : data.notes,
         sharedBy: data.sharedBy ?? existing[0].sharedBy,
+        sharedAt: new Date(),
       })
       .where(eq(recipeCopackerShares.id, existing[0].id));
     return { id: existing[0].id, created: false };

--- a/server/routers.ts
+++ b/server/routers.ts
@@ -8227,6 +8227,53 @@ Provide a brief status summary, any missing documents, and next steps.`;
         return { id: result.id, url };
       }),
 
+    // --- Shared recipes (read-only view of recipes shared with this copacker) ---
+    getSharedRecipes: copackerProcedure.query(async ({ ctx }) => {
+      if (ctx.user.role === 'copacker' && !ctx.user.linkedWarehouseId) {
+        throw new TRPCError({ code: 'FORBIDDEN', message: 'No warehouse assigned to this account' });
+      }
+      // Admin/ops viewing the portal see nothing unless they're linked to a warehouse.
+      const warehouseId = ctx.user.linkedWarehouseId;
+      if (!warehouseId) return [];
+      return manufacturingDb.getRecipesSharedWithWarehouse(warehouseId);
+    }),
+
+    getSharedRecipeDetail: copackerProcedure
+      .input(z.object({ recipeId: z.number() }))
+      .query(async ({ input, ctx }) => {
+        const warehouseId = ctx.user.linkedWarehouseId;
+        if (ctx.user.role === 'copacker' && !warehouseId) {
+          throw new TRPCError({ code: 'FORBIDDEN', message: 'No warehouse assigned to this account' });
+        }
+        // Gate by share row unless caller is admin/ops.
+        let share = warehouseId
+          ? await manufacturingDb.getRecipeShareForWarehouse(input.recipeId, warehouseId)
+          : undefined;
+        if (ctx.user.role === 'copacker' && !share) {
+          throw new TRPCError({ code: 'FORBIDDEN', message: 'This recipe is not shared with your facility' });
+        }
+        const recipe = await manufacturingDb.getRecipeById(input.recipeId);
+        if (!recipe) throw new TRPCError({ code: 'NOT_FOUND', message: 'Recipe not found' });
+
+        const shareIngredients = share?.shareIngredients ?? true;
+        const shareProcedures = share?.shareProcedures ?? true;
+
+        const lines = shareIngredients
+          ? await manufacturingDb.getRecipeLines(input.recipeId)
+          : [];
+        const procedures = shareProcedures
+          ? await manufacturingDb.getRecipeProcedures(input.recipeId)
+          : [];
+        return {
+          recipe,
+          share: share ?? null,
+          lines,
+          procedures,
+          shareIngredients,
+          shareProcedures,
+        };
+      }),
+
     // Get current biweekly period info
     getCurrentPeriod: copackerProcedure.query(async () => {
       const now = new Date();
@@ -9053,6 +9100,60 @@ Provide a brief status summary, any missing documents, and next steps.`;
           userId: ctx.user?.id,
           formulation: input.formulation,
         });
+      }),
+    // List copackers a recipe is shared with
+    listShares: opsProcedure
+      .input(z.object({ recipeId: z.number() }))
+      .query(({ input }) => manufacturingDb.getRecipeShares(input.recipeId)),
+    // Share (or update share settings) for a recipe with a copacker warehouse
+    share: opsProcedure
+      .input(z.object({
+        recipeId: z.number(),
+        warehouseId: z.number(),
+        shareIngredients: z.boolean().optional(),
+        shareProcedures: z.boolean().optional(),
+        notes: z.string().nullish(),
+      }))
+      .mutation(async ({ input, ctx }) => {
+        const warehouse = await db.getWarehouseById(input.warehouseId);
+        if (!warehouse) {
+          throw new TRPCError({ code: "NOT_FOUND", message: "Warehouse not found" });
+        }
+        if (warehouse.type !== "copacker") {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: "Recipes can only be shared with warehouses of type 'copacker'",
+          });
+        }
+        const result = await manufacturingDb.upsertRecipeShare({
+          recipeId: input.recipeId,
+          warehouseId: input.warehouseId,
+          shareIngredients: input.shareIngredients,
+          shareProcedures: input.shareProcedures,
+          notes: input.notes ?? undefined,
+          sharedBy: ctx.user?.id,
+        });
+        await createAuditLog(
+          ctx.user.id,
+          result.created ? "create" : "update",
+          "recipe_copacker_share",
+          result.id,
+          `recipe:${input.recipeId} → warehouse:${input.warehouseId}`,
+        );
+        return result;
+      }),
+    unshare: opsProcedure
+      .input(z.object({ recipeId: z.number(), warehouseId: z.number() }))
+      .mutation(async ({ input, ctx }) => {
+        await manufacturingDb.removeRecipeShare(input.recipeId, input.warehouseId);
+        await createAuditLog(
+          ctx.user.id,
+          "delete",
+          "recipe_copacker_share",
+          input.recipeId,
+          `recipe:${input.recipeId} × warehouse:${input.warehouseId}`,
+        );
+        return { success: true };
       }),
   }),
 

--- a/server/routers.ts
+++ b/server/routers.ts
@@ -9145,14 +9145,20 @@ Provide a brief status summary, any missing documents, and next steps.`;
     unshare: opsProcedure
       .input(z.object({ recipeId: z.number(), warehouseId: z.number() }))
       .mutation(async ({ input, ctx }) => {
+        const existingShares = await manufacturingDb.getRecipeShares(input.recipeId);
+        const shareToRemove = existingShares.find((share) => share.warehouseId === input.warehouseId);
+
         await manufacturingDb.removeRecipeShare(input.recipeId, input.warehouseId);
-        await createAuditLog(
-          ctx.user.id,
-          "delete",
-          "recipe_copacker_share",
-          input.recipeId,
-          `recipe:${input.recipeId} × warehouse:${input.warehouseId}`,
-        );
+
+        if (shareToRemove) {
+          await createAuditLog(
+            ctx.user.id,
+            "delete",
+            "recipe_copacker_share",
+            shareToRemove.id,
+            `recipe:${input.recipeId} × warehouse:${input.warehouseId}`,
+          );
+        }
         return { success: true };
       }),
   }),

--- a/server/routers.ts
+++ b/server/routers.ts
@@ -9130,7 +9130,7 @@ Provide a brief status summary, any missing documents, and next steps.`;
           warehouseId: input.warehouseId,
           shareIngredients: input.shareIngredients,
           shareProcedures: input.shareProcedures,
-          notes: input.notes ?? undefined,
+          notes: input.notes === undefined ? undefined : input.notes,
           sharedBy: ctx.user?.id,
         });
         await createAuditLog(


### PR DESCRIPTION
## Summary
Implements a recipe sharing system that allows operations teams to selectively share recipes (with configurable ingredient and procedure visibility) with copacker facilities. Copackers can then view shared recipes in their portal.

## Key Changes

**Database & Schema**
- Added `recipe_copacker_shares` table to track which recipes are shared with which copacker warehouses
- Includes toggles for `shareIngredients` and `shareProcedures` to control visibility granularity
- Added schema definitions and migration (0033)

**Operations Portal (Recipes.tsx)**
- Added "Share" button to recipe table rows
- New dialog for managing recipe shares with copacker warehouses
- Displays all configured copacker locations with checkboxes to toggle ingredient/procedure sharing
- Supports creating new shares, updating existing shares, and removing shares
- Uses `listShares`, `share`, and `unshare` mutations

**Copacker Portal (CopackerPortal.tsx)**
- New "Shared Recipes" card displaying recipes shared with the facility
- Table shows recipe metadata (ID, name, category, status, batch size, yield %)
- "View" button opens detailed recipe dialog
- Detail dialog conditionally displays ingredients and procedures based on share settings
- Includes notes from operations if provided
- Gracefully handles withheld sections with explanatory messages

**Backend (routers.ts & manufacturing.ts)**
- `getRecipesSharedWithWarehouse()` - retrieves recipes shared with a specific copacker
- `getRecipeShareForWarehouse()` - checks if a recipe is shared with a warehouse
- `getRecipeShares()` - lists all shares for a recipe
- `upsertRecipeShare()` - creates or updates a share with ingredient/procedure toggles
- `removeRecipeShare()` - removes a share
- New TRPC endpoints: `getSharedRecipes`, `getSharedRecipeDetail`, `listShares`, `share`, `unshare`
- Proper authorization checks to ensure copackers can only view recipes shared with their warehouse
- Audit logging for share creation, updates, and deletion

## Implementation Details
- Shares are gated by warehouse ID; copackers can only see recipes explicitly shared with their linked warehouse
- Ingredient and procedure visibility is independently toggleable per copacker
- Detail view respects share settings and shows placeholder text when sections are withheld
- Uses conditional queries (`enabled: !!viewSharedRecipeId`) to avoid unnecessary data fetching

https://claude.ai/code/session_018akiy1teXTrswDoJ4FQS9B

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-copacker recipe sharing with per-warehouse controls for ingredients and procedures. Copackers see a Shared Recipes view scoped to their linked warehouse, with sections shown only if granted.

- New Features
  - New `recipe_copacker_shares` table with per-warehouse toggles, notes, and `sharedBy/sharedAt`.
  - Ops: “Share” dialog in Recipes lists copacker warehouses, lets you share/unshare and toggle ingredients/procedures per warehouse.
  - Copacker portal: Shared Recipes table and detail dialog; ingredients/procedures withheld based on share toggles; shows notes when present; scoped to the user’s `linkedWarehouseId`.
  - TRPC: `getSharedRecipes`, `getSharedRecipeDetail`, `listShares`, `share`, `unshare` with auth checks, audit logs, and `share` validating warehouse type is "copacker".

- Migration
  - Run migration 0033 to create `recipe_copacker_shares`.
  - Ensure copacker warehouses exist (type "copacker") before sharing.

<sup>Written for commit b342ed2383c5a1149e25bd3c0d7464e2c47b9e1f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

