### PR TITLE
Claude/fix google drive access f gc mh

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,19 @@ GOOGLE_CLIENT_SECRET=
 GOOGLE_REDIRECT_URI=
 GOOGLE_SHEETS_API_KEY=
 
+# Google Service Account (optional — lets the server read private Drive folders
+# shared with the service account, without making files public or relying on a
+# user's OAuth grant). Create one in Google Cloud Console → IAM → Service
+# Accounts, download the JSON key, then share the private Drive folder with the
+# service account's email address.
+#
+# Option A (recommended): paste the full JSON key as a single-line string:
+GOOGLE_SERVICE_ACCOUNT_JSON=
+# Option B: provide email + key separately. Escape newlines in the private key
+# as \n (e.g. "-----BEGIN PRIVATE KEY-----\nMIIE...\n-----END PRIVATE KEY-----\n").
+GOOGLE_SERVICE_ACCOUNT_EMAIL=
+GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY=
+
 # Email Configuration (IMAP - for inbox scanning)
 IMAP_HOST=
 IMAP_PORT=993

--- a/client/src/pages/DataRoomDetail.tsx
+++ b/client/src/pages/DataRoomDetail.tsx
@@ -800,29 +800,22 @@ export default function DataRoomDetail() {
                         const isImg = ["png","jpg","jpeg","gif","webp","svg"].includes(ft);
                         const isOffice = ["doc","docx","xls","xlsx","ppt","pptx"].includes(ft);
 
-                        // Prefer our S3 copy over Drive's /preview iframe.
-                        // Drive refuses to render private files in a third-party
-                        // iframe unless the viewer's browser is signed into a
-                        // Google account with access, showing a "content is
-                        // blocked" screen. Our synced S3 copy has no such
-                        // restriction.
-                        if (selectedDoc.storageType === "google_drive" && !selectedDoc.storageUrl) {
-                          const drivePreviewUrl = selectedDoc.googleDriveFileId
-                            ? getGooglePreviewUrl(selectedDoc.googleDriveFileId)
-                            : selectedDoc.googleDriveWebViewLink ?? null;
-                          if (drivePreviewUrl) {
-                            return (
-                              <iframe
-                                key={selectedDoc.id}
-                                src={drivePreviewUrl}
-                                className="w-full h-full border-0"
-                                sandbox="allow-same-origin allow-scripts allow-popups"
-                                referrerPolicy="no-referrer"
-                                allow="autoplay"
-                                title={selectedDoc.name}
-                              />
-                            );
-                          }
+                        // Google Drive files: stream through our own proxy
+                        // endpoint. The server uses the connected Google
+                        // account's OAuth token to fetch the bytes on demand,
+                        // so the folder can stay private and the browser
+                        // never sees Google's third-party iframe block.
+                        if (selectedDoc.storageType === "google_drive" && selectedDoc.id != null) {
+                          return (
+                            <iframe
+                              key={selectedDoc.id}
+                              src={`/api/drive/proxy/${selectedDoc.id}`}
+                              className="w-full h-full border-0"
+                              referrerPolicy="no-referrer"
+                              allow="autoplay"
+                              title={selectedDoc.name}
+                            />
+                          );
                         }
 
                         if (!selectedDoc.storageUrl) {
@@ -830,11 +823,7 @@ export default function DataRoomDetail() {
                             <div className="flex-1 flex flex-col items-center justify-center gap-3 h-full text-muted-foreground">
                               <FileText className="h-14 w-14 opacity-20" />
                               <p className="text-sm font-medium">Preview not available</p>
-                              <p className="text-xs opacity-70">
-                                {selectedDoc.storageType === "google_drive"
-                                  ? "This file is in Google Drive but hasn't been synced to local storage yet. Run the Drive sync, or share the folder with the connected Google account so the server can download it."
-                                  : "No file URL found."}
-                              </p>
+                              <p className="text-xs opacity-70">No file URL found.</p>
                             </div>
                           );
                         }

--- a/client/src/pages/DataRoomDetail.tsx
+++ b/client/src/pages/DataRoomDetail.tsx
@@ -800,7 +800,13 @@ export default function DataRoomDetail() {
                         const isImg = ["png","jpg","jpeg","gif","webp","svg"].includes(ft);
                         const isOffice = ["doc","docx","xls","xlsx","ppt","pptx"].includes(ft);
 
-                        if (selectedDoc.storageType === "google_drive") {
+                        // Prefer our S3 copy over Drive's /preview iframe.
+                        // Drive refuses to render private files in a third-party
+                        // iframe unless the viewer's browser is signed into a
+                        // Google account with access, showing a "content is
+                        // blocked" screen. Our synced S3 copy has no such
+                        // restriction.
+                        if (selectedDoc.storageType === "google_drive" && !selectedDoc.storageUrl) {
                           const drivePreviewUrl = selectedDoc.googleDriveFileId
                             ? getGooglePreviewUrl(selectedDoc.googleDriveFileId)
                             : selectedDoc.googleDriveWebViewLink ?? null;
@@ -810,7 +816,7 @@ export default function DataRoomDetail() {
                                 key={selectedDoc.id}
                                 src={drivePreviewUrl}
                                 className="w-full h-full border-0"
-                             sandbox="allow-same-origin allow-scripts allow-popups"
+                                sandbox="allow-same-origin allow-scripts allow-popups"
                                 referrerPolicy="no-referrer"
                                 allow="autoplay"
                                 title={selectedDoc.name}
@@ -824,7 +830,11 @@ export default function DataRoomDetail() {
                             <div className="flex-1 flex flex-col items-center justify-center gap-3 h-full text-muted-foreground">
                               <FileText className="h-14 w-14 opacity-20" />
                               <p className="text-sm font-medium">Preview not available</p>
-                              <p className="text-xs opacity-70">No file URL found.</p>
+                              <p className="text-xs opacity-70">
+                                {selectedDoc.storageType === "google_drive"
+                                  ? "This file is in Google Drive but hasn't been synced to local storage yet. Run the Drive sync, or share the folder with the connected Google account so the server can download it."
+                                  : "No file URL found."}
+                              </p>
                             </div>
                           );
                         }

--- a/client/src/pages/DataRoomPublic.tsx
+++ b/client/src/pages/DataRoomPublic.tsx
@@ -59,42 +59,41 @@ function formatFileSize(bytes: number | null): string {
  * FULL content is always visible (not just a thumbnail or partial preview).
  *
  * Priority order:
- *  1. Google Drive files  → /preview URL (supports all types, full scroll)
- *  2. S3 Office files     → Microsoft Office Online embed (full workbook/doc)
- *  3. S3 PDF / txt / html → direct URL (native browser viewer)
- *  4. Images              → returns storageUrl; caller renders as <img>
- *  5. Anything else       → null (show "preview unavailable")
+ *  1. Our own S3 copy       → always safe, works for anonymous viewers
+ *  2. Google Drive /preview → only when no S3 copy exists (viewer must be
+ *                             signed into a Google account with access, or
+ *                             Google shows "This content is blocked")
+ *  3. Nothing available     → null (show "preview unavailable")
  */
 function getViewerSrc(doc: DocumentItem): { src: string | null; isImg: boolean } {
   const ft = (doc.fileType || "").toLowerCase();
   const isImg = ["png", "jpg", "jpeg", "gif", "svg", "webp"].includes(ft);
   const isOffice = ["doc", "docx", "xls", "xlsx", "ppt", "pptx"].includes(ft);
 
-  // ── Google Drive: always use /preview (full, iframe-safe, all types)
+  // ── Prefer our S3 copy whenever we have one; Drive /preview refuses to
+  //    render in iframes for private files unless the viewer's browser is
+  //    already signed into a Google account with access.
+  if (doc.storageUrl) {
+    if (isImg) return { src: doc.storageUrl, isImg: true };
+    if (isOffice) {
+      const encoded = encodeURIComponent(doc.storageUrl);
+      return { src: `https://view.officeapps.live.com/op/embed.aspx?src=${encoded}`, isImg: false };
+    }
+    return { src: doc.storageUrl, isImg: false };
+  }
+
+  // ── Fall back to Google Drive preview when we have no local copy
   if (doc.googleDriveFileId) {
     return { src: `https://drive.google.com/file/d/${doc.googleDriveFileId}/preview`, isImg: false };
   }
   if (doc.googleDriveWebViewLink) {
-    // Extract file ID from any Drive/Docs URL pattern
     const m = doc.googleDriveWebViewLink.match(/\/d\/([^/?#]+)/);
     if (m) {
       return { src: `https://drive.google.com/file/d/${m[1]}/preview`, isImg: false };
     }
   }
 
-  if (!doc.storageUrl) return { src: null, isImg: false };
-
-  // ── Images
-  if (isImg) return { src: doc.storageUrl, isImg: true };
-
-  // ── Office files: route through Microsoft Office Online Viewer
-  if (isOffice) {
-    const encoded = encodeURIComponent(doc.storageUrl);
-    return { src: `https://view.officeapps.live.com/op/embed.aspx?src=${encoded}`, isImg: false };
-  }
-
-  // ── Everything else (PDF, txt, html, csv …): direct URL
-  return { src: doc.storageUrl, isImg: false };
+  return { src: null, isImg: false };
 }
 
 function getFileIcon(fileType: string) {

--- a/client/src/pages/DataRoomPublic.tsx
+++ b/client/src/pages/DataRoomPublic.tsx
@@ -59,41 +59,39 @@ function formatFileSize(bytes: number | null): string {
  * FULL content is always visible (not just a thumbnail or partial preview).
  *
  * Priority order:
- *  1. Our own S3 copy       → always safe, works for anonymous viewers
- *  2. Google Drive /preview → only when no S3 copy exists (viewer must be
- *                             signed into a Google account with access, or
- *                             Google shows "This content is blocked")
- *  3. Nothing available     → null (show "preview unavailable")
+ *  1. Google Drive files  → our server-side proxy endpoint that streams the
+ *                            file via OAuth. The browser sees it as a
+ *                            same-origin asset, so Google's third-party
+ *                            iframe block doesn't apply and the folder can
+ *                            stay private.
+ *  2. Office files        → Microsoft Office Online embed (full workbook/doc)
+ *  3. PDF / txt / html    → direct URL (native browser viewer)
+ *  4. Images              → returns storageUrl; caller renders as <img>
+ *  5. Anything else       → null (show "preview unavailable")
  */
-function getViewerSrc(doc: DocumentItem): { src: string | null; isImg: boolean } {
+function getViewerSrc(doc: DocumentItem, linkCode?: string): { src: string | null; isImg: boolean } {
   const ft = (doc.fileType || "").toLowerCase();
   const isImg = ["png", "jpg", "jpeg", "gif", "svg", "webp"].includes(ft);
   const isOffice = ["doc", "docx", "xls", "xlsx", "ppt", "pptx"].includes(ft);
 
-  // ── Prefer our S3 copy whenever we have one; Drive /preview refuses to
-  //    render in iframes for private files unless the viewer's browser is
-  //    already signed into a Google account with access.
-  if (doc.storageUrl) {
-    if (isImg) return { src: doc.storageUrl, isImg: true };
-    if (isOffice) {
-      const encoded = encodeURIComponent(doc.storageUrl);
-      return { src: `https://view.officeapps.live.com/op/embed.aspx?src=${encoded}`, isImg: false };
-    }
-    return { src: doc.storageUrl, isImg: false };
+  // ── Google Drive: stream through our own proxy so private folders work
+  //    without exposing OAuth tokens to the browser and without requiring
+  //    the viewer's browser to be signed into a Google account.
+  if (doc.googleDriveFileId && doc.id != null) {
+    const qs = linkCode ? `?linkCode=${encodeURIComponent(linkCode)}` : "";
+    return { src: `/api/drive/proxy/${doc.id}${qs}`, isImg: false };
   }
 
-  // ── Fall back to Google Drive preview when we have no local copy
-  if (doc.googleDriveFileId) {
-    return { src: `https://drive.google.com/file/d/${doc.googleDriveFileId}/preview`, isImg: false };
-  }
-  if (doc.googleDriveWebViewLink) {
-    const m = doc.googleDriveWebViewLink.match(/\/d\/([^/?#]+)/);
-    if (m) {
-      return { src: `https://drive.google.com/file/d/${m[1]}/preview`, isImg: false };
-    }
+  if (!doc.storageUrl) return { src: null, isImg: false };
+
+  if (isImg) return { src: doc.storageUrl, isImg: true };
+
+  if (isOffice) {
+    const encoded = encodeURIComponent(doc.storageUrl);
+    return { src: `https://view.officeapps.live.com/op/embed.aspx?src=${encoded}`, isImg: false };
   }
 
-  return { src: null, isImg: false };
+  return { src: doc.storageUrl, isImg: false };
 }
 
 function getFileIcon(fileType: string) {
@@ -585,7 +583,7 @@ export default function DataRoomPublic() {
               className={`w-full h-full ${pageDirection === "left" ? "dr-page-left" : "dr-page-right"}`}
             >
               {(() => {
-                const { src, isImg } = getViewerSrc(doc);
+                const { src, isImg } = getViewerSrc(doc, linkCode);
                 if (isImg && src) {
                   return (
                     <div className="flex items-center justify-center h-full p-6">

--- a/server/_core/env.ts
+++ b/server/_core/env.ts
@@ -48,6 +48,14 @@ export const ENV = {
     googleRedirectUri: process.env.GOOGLE_REDIRECT_URI ?? "",
     appUrl: process.env.APP_URL ?? "http://localhost:3000",
 
+    // Google Service Account (for reading private Drive folders shared with the
+    // service account directly, bypassing per-user OAuth). Either provide the
+    // whole JSON key via GOOGLE_SERVICE_ACCOUNT_JSON, or the email + private key
+    // pair. Private key literal newlines may be escaped as "\n".
+    googleServiceAccountJson: process.env.GOOGLE_SERVICE_ACCOUNT_JSON ?? "",
+    googleServiceAccountEmail: process.env.GOOGLE_SERVICE_ACCOUNT_EMAIL ?? "",
+    googleServiceAccountPrivateKey: process.env.GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY ?? "",
+
     // QuickBooks OAuth configuration
     quickbooksClientId: process.env.QUICKBOOKS_CLIENT_ID ?? "",
     quickbooksClientSecret: process.env.QUICKBOOKS_CLIENT_SECRET ?? "",

--- a/server/_core/googleDrive.ts
+++ b/server/_core/googleDrive.ts
@@ -5,6 +5,46 @@
 
 import { ENV } from "./env";
 import { createSignedOAuthState } from "./crypto";
+import {
+  getServiceAccountAccessToken,
+  getServiceAccountEmail,
+  isServiceAccountConfigured,
+} from "./googleServiceAccount";
+
+/**
+ * Fetch a Drive API URL with Bearer auth, and if the user's token is
+ * forbidden, retry with the service-account token when configured. This lets
+ * private folders that are shared with the service account be read even when
+ * the logged-in user has no direct access.
+ */
+async function driveFetch(url: string, userAccessToken: string): Promise<Response> {
+  const primary = await fetch(url, {
+    headers: { Authorization: `Bearer ${userAccessToken}` },
+  });
+  if (primary.status !== 403 && primary.status !== 401) return primary;
+  if (!isServiceAccountConfigured()) return primary;
+
+  const saToken = await getServiceAccountAccessToken();
+  if (!saToken) return primary;
+
+  const retry = await fetch(url, {
+    headers: { Authorization: `Bearer ${saToken}` },
+  });
+  // Only prefer the retry when it actually succeeded; otherwise surface the
+  // original error so callers can see the user-scoped failure reason.
+  return retry.ok ? retry : primary;
+}
+
+/**
+ * Build a "share this folder with…" hint for 403/404 errors.
+ */
+function permissionHint(): string {
+  const saEmail = getServiceAccountEmail();
+  if (saEmail) {
+    return ` Share the file or parent folder with ${saEmail} (Viewer is enough) so the server can read it without making it public.`;
+  }
+  return " Share the file or parent folder with the connected Google account, or configure GOOGLE_SERVICE_ACCOUNT_JSON and share the folder with the service account's email.";
+}
 
 // Google Drive API types
 export interface DriveFile {
@@ -107,17 +147,14 @@ export async function listDriveFolders(
     }
     
     const url = `${GOOGLE_DRIVE_API}/files?q=${encodeURIComponent(query)}&fields=files(id,name,mimeType,webViewLink,parents)&orderBy=name&supportsAllDrives=true&includeItemsFromAllDrives=true`;
-    
-    const response = await fetch(url, {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-      },
-    });
-    
+
+    const response = await driveFetch(url, accessToken);
+
     if (!response.ok) {
       const error = await response.text();
       console.error("[GoogleDrive] Failed to list folders:", error);
-      return { folders: [], error: `Failed to list folders: ${response.status}` };
+      const hint = response.status === 403 || response.status === 404 ? permissionHint() : "";
+      return { folders: [], error: `Failed to list folders: ${response.status}.${hint}` };
     }
     
     const data = await response.json();
@@ -139,17 +176,14 @@ export async function listDriveFiles(
     const query = `'${folderId}' in parents and trashed=false and mimeType!='${FOLDER_MIME_TYPE}'`;
     
     const url = `${GOOGLE_DRIVE_API}/files?q=${encodeURIComponent(query)}&fields=files(id,name,mimeType,size,webViewLink,thumbnailLink,iconLink,createdTime,modifiedTime,parents)&orderBy=name&supportsAllDrives=true&includeItemsFromAllDrives=true`;
-    
-    const response = await fetch(url, {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-      },
-    });
-    
+
+    const response = await driveFetch(url, accessToken);
+
     if (!response.ok) {
       const error = await response.text();
       console.error("[GoogleDrive] Failed to list files:", error);
-      return { files: [], error: `Failed to list files: ${response.status}` };
+      const hint = response.status === 403 || response.status === 404 ? permissionHint() : "";
+      return { files: [], error: `Failed to list files: ${response.status}.${hint}` };
     }
     
     const data = await response.json();
@@ -231,17 +265,14 @@ export async function getFileMetadata(
   fileId: string
 ): Promise<{ file: DriveFile | null; error?: string }> {
   try {
-    const url = `${GOOGLE_DRIVE_API}/files/${fileId}?fields=id,name,mimeType,size,webViewLink,thumbnailLink,iconLink,createdTime,modifiedTime,parents`;
-    
-    const response = await fetch(url, {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-      },
-    });
-    
+    const url = `${GOOGLE_DRIVE_API}/files/${fileId}?fields=id,name,mimeType,size,webViewLink,thumbnailLink,iconLink,createdTime,modifiedTime,parents&supportsAllDrives=true`;
+
+    const response = await driveFetch(url, accessToken);
+
     if (!response.ok) {
       const error = await response.text();
-      return { file: null, error: `Failed to get file: ${response.status}` };
+      const hint = response.status === 403 || response.status === 404 ? permissionHint() : "";
+      return { file: null, error: `Failed to get file: ${response.status}. ${error}${hint}` };
     }
     
     const file = await response.json();
@@ -287,18 +318,15 @@ export async function downloadFile(
     if (exportType) {
       url = `${GOOGLE_DRIVE_API}/files/${fileId}/export?mimeType=${encodeURIComponent(exportType.mimeType)}`;
     } else {
-      url = `${GOOGLE_DRIVE_API}/files/${fileId}?alt=media`;
+      url = `${GOOGLE_DRIVE_API}/files/${fileId}?alt=media&supportsAllDrives=true`;
     }
-    
-    const response = await fetch(url, {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-      },
-    });
-    
+
+    const response = await driveFetch(url, accessToken);
+
     if (!response.ok) {
-      const error = await response.text();
-      return { content: null, error: `Failed to download: ${response.status}` };
+      const body = await response.text();
+      const hint = response.status === 403 || response.status === 404 ? permissionHint() : "";
+      return { content: null, error: `Failed to download: ${response.status}. ${body}${hint}` };
     }
     
     const arrayBuffer = await response.arrayBuffer();
@@ -339,12 +367,12 @@ export async function downloadDriveFile(
       url = `https://www.googleapis.com/drive/v3/files/${fileId}?alt=media&supportsAllDrives=true`;
     }
 
-    const response = await fetch(url, {
-      headers: { Authorization: `Bearer ${accessToken}` },
-    });
+    const response = await driveFetch(url, accessToken);
 
     if (!response.ok) {
-      return { error: `Download failed: ${response.status}` };
+      const body = await response.text();
+      const hint = response.status === 403 || response.status === 404 ? permissionHint() : "";
+      return { error: `Download failed: ${response.status}. ${body}${hint}` };
     }
 
     const arrayBuffer = await response.arrayBuffer();
@@ -363,17 +391,16 @@ export async function getFolderInfo(
 ): Promise<{ folder: DriveFolder | null; error?: string }> {
   try {
     const url = `${GOOGLE_DRIVE_API}/files/${folderId}?fields=id,name,mimeType,webViewLink,parents&supportsAllDrives=true&includeItemsFromAllDrives=true`;
-    
-    const response = await fetch(url, {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-      },
-    });
-    
+
+    const response = await driveFetch(url, accessToken);
+
     if (!response.ok) {
       const error = await response.text();
       console.error("[GoogleDrive] getFolderInfo failed:", response.status, error);
-      return { folder: null, error: `Failed to get folder (${response.status}): ${error}. Make sure the folder is shared with your Google account and you've connected Google with full Drive access.` };
+      const hint = response.status === 403 || response.status === 404
+        ? permissionHint()
+        : "";
+      return { folder: null, error: `Failed to get folder (${response.status}): ${error}.${hint}` };
     }
     
     const folder = await response.json();

--- a/server/_core/googleDrive.ts
+++ b/server/_core/googleDrive.ts
@@ -17,7 +17,7 @@ import {
  * private folders that are shared with the service account be read even when
  * the logged-in user has no direct access.
  */
-async function driveFetch(url: string, userAccessToken: string): Promise<Response> {
+export async function driveFetch(url: string, userAccessToken: string): Promise<Response> {
   const primary = await fetch(url, {
     headers: { Authorization: `Bearer ${userAccessToken}` },
   });
@@ -280,6 +280,26 @@ export async function getFileMetadata(
   } catch (error: any) {
     return { file: null, error: error.message };
   }
+}
+
+/**
+ * Resolve the Drive URL to fetch a file's bytes from, plus the effective
+ * output MIME type after any Google Workspace → PDF/PNG export conversion.
+ * Used by the streaming proxy endpoint so the browser gets a viewable file
+ * without the server having to buffer it.
+ */
+export function resolveDriveStreamUrl(fileId: string, mimeType: string): { url: string; outMime: string } {
+  const exportType = GOOGLE_DOCS_EXPORT_TYPES[mimeType];
+  if (exportType) {
+    return {
+      url: `${GOOGLE_DRIVE_API}/files/${fileId}/export?mimeType=${encodeURIComponent(exportType.mimeType)}`,
+      outMime: exportType.mimeType,
+    };
+  }
+  return {
+    url: `${GOOGLE_DRIVE_API}/files/${fileId}?alt=media&supportsAllDrives=true`,
+    outMime: mimeType,
+  };
 }
 
 /**

--- a/server/_core/googleServiceAccount.ts
+++ b/server/_core/googleServiceAccount.ts
@@ -1,0 +1,143 @@
+/**
+ * Google service account authentication for Drive API.
+ *
+ * Lets the server read private Drive folders that are shared with the service
+ * account's email, without making them public and without depending on a
+ * user's OAuth grant. Used as a fallback when user-OAuth returns 403.
+ *
+ * Configure via GOOGLE_SERVICE_ACCOUNT_JSON (full key JSON) or the
+ * GOOGLE_SERVICE_ACCOUNT_EMAIL + GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY pair.
+ */
+
+import { createSign } from "node:crypto";
+import { ENV } from "./env";
+
+interface ServiceAccountKey {
+  clientEmail: string;
+  privateKey: string;
+}
+
+interface CachedToken {
+  token: string;
+  expiresAt: number;
+}
+
+let parsedKey: ServiceAccountKey | null | undefined;
+let cachedToken: CachedToken | null = null;
+let inFlight: Promise<string | null> | null = null;
+
+function parseKey(): ServiceAccountKey | null {
+  if (parsedKey !== undefined) return parsedKey;
+
+  if (ENV.googleServiceAccountJson) {
+    try {
+      const raw = JSON.parse(ENV.googleServiceAccountJson);
+      if (raw.client_email && raw.private_key) {
+        parsedKey = {
+          clientEmail: raw.client_email,
+          privateKey: String(raw.private_key).replace(/\\n/g, "\n"),
+        };
+        return parsedKey;
+      }
+      console.warn("[GoogleServiceAccount] GOOGLE_SERVICE_ACCOUNT_JSON is missing client_email or private_key");
+    } catch (err) {
+      console.warn("[GoogleServiceAccount] GOOGLE_SERVICE_ACCOUNT_JSON is not valid JSON:", (err as Error).message);
+    }
+  }
+
+  if (ENV.googleServiceAccountEmail && ENV.googleServiceAccountPrivateKey) {
+    parsedKey = {
+      clientEmail: ENV.googleServiceAccountEmail,
+      privateKey: ENV.googleServiceAccountPrivateKey.replace(/\\n/g, "\n"),
+    };
+    return parsedKey;
+  }
+
+  parsedKey = null;
+  return null;
+}
+
+function base64url(input: Buffer | string): string {
+  const buf = typeof input === "string" ? Buffer.from(input) : input;
+  return buf.toString("base64").replace(/=+$/g, "").replace(/\+/g, "-").replace(/\//g, "_");
+}
+
+export function isServiceAccountConfigured(): boolean {
+  return parseKey() !== null;
+}
+
+export function getServiceAccountEmail(): string | null {
+  return parseKey()?.clientEmail ?? null;
+}
+
+async function requestAccessToken(key: ServiceAccountKey): Promise<string | null> {
+  const now = Math.floor(Date.now() / 1000);
+  const header = { alg: "RS256", typ: "JWT" };
+  const claims = {
+    iss: key.clientEmail,
+    scope: "https://www.googleapis.com/auth/drive.readonly",
+    aud: "https://oauth2.googleapis.com/token",
+    iat: now,
+    exp: now + 3600,
+  };
+
+  const signingInput = `${base64url(JSON.stringify(header))}.${base64url(JSON.stringify(claims))}`;
+  const signer = createSign("RSA-SHA256");
+  signer.update(signingInput);
+  signer.end();
+
+  let signature: string;
+  try {
+    signature = base64url(signer.sign(key.privateKey));
+  } catch (err) {
+    console.error("[GoogleServiceAccount] Failed to sign JWT — check the private key format:", (err as Error).message);
+    return null;
+  }
+
+  const assertion = `${signingInput}.${signature}`;
+
+  const response = await fetch("https://oauth2.googleapis.com/token", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+      assertion,
+    }),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    console.error("[GoogleServiceAccount] Token request failed:", response.status, body);
+    return null;
+  }
+
+  const data = (await response.json()) as { access_token?: string; expires_in?: number };
+  if (!data.access_token) {
+    console.error("[GoogleServiceAccount] Token response missing access_token");
+    return null;
+  }
+
+  const expiresIn = data.expires_in ?? 3600;
+  cachedToken = { token: data.access_token, expiresAt: now + expiresIn };
+  return data.access_token;
+}
+
+/**
+ * Returns a valid service-account access token, minting a new one when needed.
+ * Returns null when no service account is configured or token acquisition fails.
+ */
+export async function getServiceAccountAccessToken(): Promise<string | null> {
+  const key = parseKey();
+  if (!key) return null;
+
+  const now = Math.floor(Date.now() / 1000);
+  if (cachedToken && cachedToken.expiresAt > now + 60) {
+    return cachedToken.token;
+  }
+
+  if (inFlight) return inFlight;
+  inFlight = requestAccessToken(key).finally(() => {
+    inFlight = null;
+  });
+  return inFlight;
+}

--- a/server/_core/index.ts
+++ b/server/_core/index.ts
@@ -733,6 +733,88 @@ async function startServer() {
     return handleGoogleOAuthCallback(req, res, redirectUri);
   });
 
+  // Google Drive streaming proxy — fetches a Drive file's bytes using the
+  // connected account's OAuth token (with service-account fallback) and pipes
+  // them straight to the browser. This lets the data room viewer iframe load
+  // private Drive files from our own origin, bypassing Google's third-party
+  // iframe block, without ever persisting the file to our storage.
+  //
+  // Access control:
+  //   - authenticated user must own the data room, OR
+  //   - linkCode query param must resolve to an active share link for the
+  //     data room that contains this document.
+  app.get('/api/drive/proxy/:documentId', async (req, res) => {
+    try {
+      const documentId = parseInt(req.params.documentId, 10);
+      if (!Number.isFinite(documentId)) return res.status(400).send('Invalid document id');
+
+      const doc = await db.getDataRoomDocumentById(documentId);
+      if (!doc) return res.status(404).send('Document not found');
+      if (!doc.googleDriveFileId) return res.status(400).send('Not a Google Drive document');
+
+      const dataRoom = await db.getDataRoomById(doc.dataRoomId);
+      if (!dataRoom) return res.status(404).send('Data room not found');
+
+      // Resolve who the Drive OAuth token should come from and authorize the
+      // request. The data room owner's token is always the one used to fetch
+      // the file — viewers never need their own Google connection.
+      let ownerUserId: number | null = null;
+      const linkCode = typeof req.query.linkCode === 'string' ? req.query.linkCode : null;
+
+      if (linkCode) {
+        const link = await db.getDataRoomLinkByCode(linkCode);
+        if (!link || !link.isActive) return res.status(403).send('Share link is not active');
+        if (link.expiresAt && new Date(link.expiresAt) < new Date()) return res.status(403).send('Share link has expired');
+        if (link.dataRoomId !== doc.dataRoomId) return res.status(403).send('Document not in this data room');
+        ownerUserId = dataRoom.ownerId;
+      } else {
+        const { sdk } = await import('./sdk');
+        let user: any = null;
+        try { user = await sdk.authenticateRequest(req); } catch { /* unauthenticated */ }
+        if (!user) return res.status(401).send('Not authenticated');
+        if (user.id !== dataRoom.ownerId) return res.status(403).send('Forbidden');
+        ownerUserId = user.id;
+      }
+
+      if (!ownerUserId) return res.status(500).send('Unable to resolve Drive owner');
+
+      const { accessToken, error: tokenError } = await getValidGoogleToken(ownerUserId);
+      if (tokenError || !accessToken) {
+        return res.status(502).send(`Google Drive not connected: ${tokenError || 'no token'}`);
+      }
+
+      const { resolveDriveStreamUrl, driveFetch } = await import('./googleDrive');
+      const { url, outMime } = resolveDriveStreamUrl(doc.googleDriveFileId, doc.mimeType || '');
+
+      const driveResponse = await driveFetch(url, accessToken);
+      if (!driveResponse.ok || !driveResponse.body) {
+        const body = await driveResponse.text().catch(() => '');
+        return res.status(driveResponse.status || 502).send(`Drive fetch failed: ${driveResponse.status}. ${body}`);
+      }
+
+      res.setHeader('Content-Type', driveResponse.headers.get('content-type') || outMime || 'application/octet-stream');
+      const len = driveResponse.headers.get('content-length');
+      if (len) res.setHeader('Content-Length', len);
+      res.setHeader('Content-Disposition', `inline; filename="${encodeURIComponent(doc.name || 'file')}"`);
+      res.setHeader('Cache-Control', 'private, max-age=60');
+
+      // Pipe Drive's response body to the client. Node's fetch returns a web
+      // ReadableStream; convert it to a Node stream for res.pipe semantics.
+      const { Readable } = await import('node:stream');
+      const nodeStream = Readable.fromWeb(driveResponse.body as any);
+      nodeStream.pipe(res);
+      nodeStream.on('error', (err) => {
+        console.error('[DriveProxy] Stream error:', err);
+        if (!res.headersSent) res.status(502);
+        res.end();
+      });
+    } catch (err: any) {
+      console.error('[DriveProxy] Handler error:', err);
+      if (!res.headersSent) res.status(500).send(`Proxy error: ${err.message}`);
+      else res.end();
+    }
+  });
+
   // Shopify OAuth callback
   app.get('/api/shopify/callback', oauthCallbackLimiter, async (req, res) => {
     const { code, shop, state } = req.query;
@@ -1242,7 +1324,7 @@ async function startServer() {
         console.log("[Data Room Sync] Starting daily auto-sync");
         setInterval(async () => {
           try {
-            const { syncDriveFolder, downloadDriveFile, getSimpleFileType } = await import("../routers").then(() => import("./googleDrive"));
+            const { syncDriveFolder, getSimpleFileType } = await import("../routers").then(() => import("./googleDrive"));
             const rooms = await db.getDataRooms();
             for (const room of rooms) {
               if (room.googleDriveFolderId) {
@@ -1251,7 +1333,6 @@ async function startServer() {
                   try {
                     const syncResult = await syncDriveFolder(roomAccessToken, room.googleDriveFolderId);
                     if (syncResult.success && syncResult.files.length > 0) {
-                      // Check for new files not yet in the data room
                       const existingDocs = await db.getDataRoomDocuments(room.id);
                       const existingDriveIds = new Set(
                         existingDocs.filter(d => d.googleDriveFileId).map(d => d.googleDriveFileId!)
@@ -1261,30 +1342,16 @@ async function startServer() {
                       for (const driveFile of syncResult.files) {
                         if (existingDriveIds.has(driveFile.id)) continue;
 
-                        // Download actual file content
-                        const downloaded = await downloadDriveFile(roomAccessToken, driveFile.id, driveFile.mimeType);
-                        const isGoogleWorkspaceFile = driveFile.mimeType.startsWith('application/vnd.google-apps.');
-                        const displayName = isGoogleWorkspaceFile ? `${driveFile.name}.pdf` : driveFile.name;
-                        const effectiveMimeType = ('exportedMimeType' in downloaded) ? downloaded.exportedMimeType : driveFile.mimeType;
-                        const fileType = getSimpleFileType(effectiveMimeType);
-
-                        let storageUrl: string | undefined;
-                        let storageType: string = 'google_drive';
-
-                        if ('buffer' in downloaded && downloaded.buffer.length < 5 * 1024 * 1024) {
-                          storageUrl = `data:${downloaded.exportedMimeType};base64,${downloaded.buffer.toString('base64')}`;
-                          storageType = 's3';
-                        }
-
+                        // Metadata-only record. Content stays in Drive and is
+                        // streamed on demand via /api/drive/proxy/:documentId.
                         await db.createDataRoomDocument({
                           dataRoomId: room.id,
                           folderId: null,
-                          name: displayName,
-                          fileType,
-                          mimeType: effectiveMimeType,
-                          fileSize: ('buffer' in downloaded) ? downloaded.buffer.length : (driveFile.size ? parseInt(driveFile.size) : undefined),
-                          storageType: storageType as any,
-                          storageUrl,
+                          name: driveFile.name,
+                          fileType: getSimpleFileType(driveFile.mimeType),
+                          mimeType: driveFile.mimeType,
+                          fileSize: driveFile.size ? parseInt(driveFile.size) : undefined,
+                          storageType: 'google_drive',
                           googleDriveFileId: driveFile.id,
                           googleDriveWebViewLink: driveFile.webViewLink,
                           thumbnailUrl: driveFile.thumbnailLink,

--- a/server/googleDriveSyncService.ts
+++ b/server/googleDriveSyncService.ts
@@ -6,12 +6,9 @@
 import {
   syncDriveFolder,
   listDriveFolders,
-  downloadFile,
   getSimpleFileType,
-  DriveFile,
 } from './_core/googleDrive';
 import * as db from './db';
-import { storagePut } from './storage';
 
 interface SyncOptions {
   dataRoomId: number;
@@ -180,53 +177,39 @@ export async function syncGoogleDriveFolder(options: SyncOptions): Promise<SyncR
         }
 
         if (existingDoc) {
-          // Check if file has been modified
           const driveModified = file.modifiedTime ? new Date(file.modifiedTime).getTime() : 0;
           const docModified = existingDoc.updatedAt ? new Date(existingDoc.updatedAt).getTime() : 0;
 
           if (driveModified > docModified) {
-            // File has been updated - re-download and update
-            const downloaded = await downloadAndUploadFile(file, options);
-
-            if (downloaded) {
-              await db.updateDataRoomDocument(existingDoc.id, {
-                name: file.name,
-                folderId,
-                storageUrl: downloaded.url,
-                storageKey: downloaded.key,
-                fileSize: file.size ? parseInt(file.size) : undefined,
-                mimeType: file.mimeType,
-              });
-              filesUpdated++;
-            } else {
-              warnings.push(`Failed to update "${file.name}"`);
-            }
+            // Refresh metadata only — file content stays in Google Drive and
+            // is served on demand via /api/drive/proxy/:documentId.
+            await db.updateDataRoomDocument(existingDoc.id, {
+              name: file.name,
+              folderId,
+              fileSize: file.size ? parseInt(file.size) : undefined,
+              mimeType: file.mimeType,
+            });
+            filesUpdated++;
           } else {
             filesSkipped++;
           }
         } else {
-          // New file - download and create
-          const downloaded = await downloadAndUploadFile(file, options);
-
-          if (downloaded) {
-            await db.createDataRoomDocument({
-              dataRoomId: options.dataRoomId,
-              folderId,
-              name: file.name,
-              fileType: getSimpleFileType(file.mimeType),
-              mimeType: file.mimeType,
-              fileSize: file.size ? parseInt(file.size) : undefined,
-              storageType: 's3',
-              storageUrl: downloaded.url,
-              storageKey: downloaded.key,
-              googleDriveFileId: file.id,
-              googleDriveWebViewLink: file.webViewLink,
-              thumbnailUrl: file.thumbnailLink,
-            });
-            filesAdded++;
-          } else {
-            warnings.push(`Failed to download "${file.name}"`);
-          }
+          // Create a metadata-only record pointing at the Drive file. The
+          // viewer streams the bytes through /api/drive/proxy/:documentId at
+          // render time, so no copy is ever made in our storage.
+          await db.createDataRoomDocument({
+            dataRoomId: options.dataRoomId,
+            folderId,
+            name: file.name,
+            fileType: getSimpleFileType(file.mimeType),
+            mimeType: file.mimeType,
+            fileSize: file.size ? parseInt(file.size) : undefined,
+            storageType: 'google_drive',
+            googleDriveFileId: file.id,
+            googleDriveWebViewLink: file.webViewLink,
+            thumbnailUrl: file.thumbnailLink,
+          });
+          filesAdded++;
         }
       } catch (fileError: any) {
         warnings.push(`Error processing "${file.name}": ${fileError.message}`);
@@ -244,58 +227,6 @@ export async function syncGoogleDriveFolder(options: SyncOptions): Promise<SyncR
     };
   } catch (error: any) {
     throw new Error(`Sync failed: ${error.message}`);
-  }
-}
-
-/**
- * Download a file from Google Drive and upload to our storage
- */
-async function downloadAndUploadFile(
-  file: DriveFile,
-  options: SyncOptions
-): Promise<{ url: string; key: string } | null> {
-  try {
-    // Download the file from Google Drive
-    const { content, error } = await downloadFile(
-      options.accessToken,
-      file.id,
-      file.mimeType
-    );
-
-    if (error || !content) {
-      console.error(`[DriveSync] Failed to download ${file.name}:`, error);
-      return null;
-    }
-
-    // Upload to our storage with sanitized filename
-    // Sanitize filename to prevent path traversal and S3 key issues:
-    // 1. Replace path separators (/ \) with underscores
-    // 2. Keep only safe characters: alphanumeric, spaces, dots, dashes, underscores
-    // 3. Limit length to prevent excessively long keys
-    let sanitizedName = file.name
-      .replace(/[\/\\]/g, '_')     // Replace slashes with underscores
-      .replace(/[^\w\s.-]/g, '')   // Keep only word chars (\w includes a-zA-Z0-9_), spaces, dots, dashes
-      .replace(/\s+/g, '_')        // Replace spaces with underscores for cleaner URLs
-      .substring(0, 200);          // Limit filename length
-    
-    // Provide fallback if sanitization results in empty string
-    if (!sanitizedName || sanitizedName.trim() === '') {
-      sanitizedName = 'unnamed_file';
-    }
-    
-    const key = `dataroom/${options.dataRoomId}/drive-sync/${Date.now()}-${sanitizedName}`;
-
-    const result = await storagePut(key, content, file.mimeType);
-
-    if (!result.url) {
-      console.error(`[DriveSync] Failed to upload ${file.name}`);
-      return null;
-    }
-
-    return { url: result.url, key };
-  } catch (error: any) {
-    console.error(`[DriveSync] Error processing ${file.name}:`, error);
-    return null;
   }
 }
 

--- a/server/routers.ts
+++ b/server/routers.ts
@@ -37,7 +37,7 @@ import { storagePut } from "./storage";
 import { nanoid } from "nanoid";
 import { sendGmailMessage, createGmailDraft, listGmailMessages, getGmailMessage, replyToGmailMessage, getGmailProfile, type GmailSendOptions, type GmailDraftOptions } from "./_core/gmail";
 import { createGoogleDoc, insertTextInDoc, getGoogleDoc, updateGoogleDoc, createGoogleSheet, updateGoogleSheet, appendToGoogleSheet, getGoogleSheetValues, shareGoogleFile, getFileShareableLink } from "./_core/googleWorkspace";
-import { getGoogleFullAccessAuthUrl, syncDriveFolder, listDriveFolders, listDriveFiles, getFileMetadata, getFolderInfo, getSimpleFileType, downloadDriveFile } from "./_core/googleDrive";
+import { getGoogleFullAccessAuthUrl, syncDriveFolder, listDriveFolders, listDriveFiles, getFileMetadata, getFolderInfo, getSimpleFileType } from "./_core/googleDrive";
 import { getQuickBooksAuthUrl, validateOAuthState, exchangeCodeForToken, refreshQuickBooksToken, getCompanyInfo, getChartOfAccounts, getQuickBooksItems } from "./_core/quickbooks";
 import { listAllTranscripts, getTranscript, extractParticipants, parseActionItems, validateApiKey as validateFirefliesApiKey } from "./_core/fireflies";
 import { queueFirefliesActionItemsForApproval } from "./firefliesSyncService";
@@ -12959,92 +12959,6 @@ Ask if they received the original request and if they can provide a quote.`;
           return { success: true };
         }),
     }),
-
-    // Re-download all documents that still have storageType='google_drive' and no storageUrl
-    redownloadAll: protectedProcedure
-      .input(z.object({ dataRoomId: z.number() }))
-      .mutation(async ({ input, ctx }) => {
-        const room = await db.getDataRoomById(input.dataRoomId);
-        if (!room) throw new TRPCError({ code: 'NOT_FOUND', message: 'Data room not found' });
-        if (room.ownerId !== ctx.user.id && ctx.user.role !== 'admin') {
-          throw new TRPCError({ code: 'FORBIDDEN', message: 'Access denied' });
-        }
-
-        const { accessToken, error } = await getValidGoogleToken(ctx.user.id);
-        if (error) {
-          throw new TRPCError({ code: 'PRECONDITION_FAILED', message: error });
-        }
-
-        // Get all documents that are still google_drive type with no storageUrl
-        const allDocs = await db.getDataRoomDocuments(input.dataRoomId);
-        const docsToRedownload = allDocs.filter(
-          (d) => d.storageType === 'google_drive' && !d.storageUrl && d.googleDriveFileId
-        );
-
-        let successCount = 0;
-        let failCount = 0;
-
-        for (const doc of docsToRedownload) {
-          try {
-            const downloaded = await downloadDriveFile(
-              accessToken,
-              doc.googleDriveFileId!,
-              doc.mimeType || 'application/octet-stream'
-            );
-
-            if ('error' in downloaded) {
-              console.warn(`[RedownloadAll] Failed to download ${doc.name}: ${downloaded.error}`);
-              failCount++;
-              continue;
-            }
-
-            const isGoogleWorkspaceFile = (doc.mimeType || '').startsWith('application/vnd.google-apps.');
-            const effectiveMimeType = downloaded.exportedMimeType;
-            const displayName = isGoogleWorkspaceFile && !doc.name.endsWith('.pdf')
-              ? `${doc.name}.pdf`
-              : doc.name;
-
-            let newStorageUrl: string | undefined;
-            let newStorageKey: string | undefined;
-
-            // Try S3 first
-            try {
-              const fileKey = `dataroom/${input.dataRoomId}/${nanoid()}-${displayName}`;
-              const result = await storagePut(fileKey, downloaded.buffer, effectiveMimeType);
-              newStorageUrl = result.url;
-              newStorageKey = result.key;
-            } catch {
-              // S3 not configured — store as base64 data URL for files < 5MB
-              if (downloaded.buffer.length < 5 * 1024 * 1024) {
-                newStorageUrl = `data:${effectiveMimeType};base64,${downloaded.buffer.toString('base64')}`;
-              }
-            }
-
-            if (newStorageUrl) {
-              await db.updateDataRoomDocument(doc.id, {
-                storageUrl: newStorageUrl,
-                storageKey: newStorageKey,
-                storageType: 's3',
-                mimeType: effectiveMimeType,
-                name: displayName,
-                fileSize: downloaded.buffer.length,
-              } as any);
-              successCount++;
-            } else {
-              failCount++;
-            }
-          } catch (e) {
-            console.warn(`[RedownloadAll] Error processing ${doc.name}:`, e);
-            failCount++;
-          }
-        }
-
-        return {
-          total: docsToRedownload.length,
-          success: successCount,
-          failed: failCount,
-        };
-      }),
 
     // Sync from Google Drive — one-click sync of an entire Drive folder (and subfolders) into the data room
     syncFromDrive: protectedProcedure


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stream private Google Drive files through a server proxy with a service‑account fallback, fixing blocked Drive iframes and removing the need to copy files to our storage. The viewer now loads files from our origin, and Drive API calls retry with a service account when configured.

- **New Features**
  - Added `/api/drive/proxy/:documentId` to stream Drive files via the data room owner’s Google OAuth, with service‑account fallback; supports public links via `?linkCode=`.
  - Updated data room viewers to iframe the proxy endpoint (private and public pages).
  - Introduced service account auth (optional). Configure via `GOOGLE_SERVICE_ACCOUNT_JSON` or `GOOGLE_SERVICE_ACCOUNT_EMAIL` + `GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY`. Drive calls use a new `driveFetch` that retries on 401/403 and surface a “share with <service account email>” hint.

- **Migration**
  - Optional: set the service account env vars and share the Drive folder with that email to enable private-folder access without making files public.
  - Drive sync no longer uploads files to S3; documents are metadata-only with `storageType='google_drive'` and are streamed on demand. Remove any workflows relying on `redownloadAll` or expecting `storageUrl` for Drive documents.

<sup>Written for commit 9544771f9270a23630c7fefa257928971752b594. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

