### PR TITLE
Fix data room viewer for private Google Drive folders (stream via proxy, no S3 copy)

### DIFF
--- a/client/src/pages/settings/Integrations.tsx
+++ b/client/src/pages/settings/Integrations.tsx
@@ -786,7 +786,9 @@ export default function IntegrationsPage() {
                         </>
                       ) : (
                         <p className="text-sm text-muted-foreground mt-1">
-                          Not configured. Set <code className="text-xs">GOOGLE_SERVICE_ACCOUNT_JSON</code> in the server environment
+                          Not configured. Set either <code className="text-xs">GOOGLE_SERVICE_ACCOUNT_JSON</code> or both{" "}
+                          <code className="text-xs">GOOGLE_SERVICE_ACCOUNT_EMAIL</code> and{" "}
+                          <code className="text-xs">GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY</code> in the server environment
                           to let the app read private Drive folders without relying on a user OAuth grant.
                         </p>
                       )}

--- a/client/src/pages/settings/Integrations.tsx
+++ b/client/src/pages/settings/Integrations.tsx
@@ -756,10 +756,41 @@ export default function IntegrationsPage() {
                       {status?.googleWorkspace?.configured ? 'Google Workspace Connected' : 'Google Workspace Not Connected'}
                     </h4>
                     <p className="text-sm text-muted-foreground">
-                      {status?.googleWorkspace?.configured 
+                      {status?.googleWorkspace?.configured
                         ? `Connected as ${status.googleWorkspace.email}`
                         : 'Connect your Google account to create and manage Workspace files'}
                     </p>
+                  </div>
+                </div>
+
+                <div className="p-4 border rounded-lg">
+                  <div className="flex items-start gap-3">
+                    <div className={`mt-0.5 p-2 rounded-full ${status?.googleDriveServiceAccount?.configured ? 'bg-green-500/10' : 'bg-muted'}`}>
+                      {status?.googleDriveServiceAccount?.configured ? (
+                        <CheckCircle2 className="w-4 h-4 text-green-500" />
+                      ) : (
+                        <AlertCircle className="w-4 h-4 text-muted-foreground" />
+                      )}
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <h4 className="font-medium text-sm">Drive Service Account (optional fallback)</h4>
+                      {status?.googleDriveServiceAccount?.configured ? (
+                        <>
+                          <p className="text-sm text-muted-foreground mt-1">
+                            Configured. Share private folders with the address below so the server can read them
+                            without making the folder public, even if the connected Google account above loses access.
+                          </p>
+                          <code className="mt-2 inline-block text-xs px-2 py-1 rounded bg-muted break-all">
+                            {status.googleDriveServiceAccount.email}
+                          </code>
+                        </>
+                      ) : (
+                        <p className="text-sm text-muted-foreground mt-1">
+                          Not configured. Set <code className="text-xs">GOOGLE_SERVICE_ACCOUNT_JSON</code> in the server environment
+                          to let the app read private Drive folders without relying on a user OAuth grant.
+                        </p>
+                      )}
+                    </div>
                   </div>
                 </div>
 

--- a/drizzle/0035_drive_docs_metadata_only.sql
+++ b/drizzle/0035_drive_docs_metadata_only.sql
@@ -1,0 +1,12 @@
+-- Migration 0035: Convert existing Drive-synced documents to metadata-only.
+-- Drive files are now streamed through /api/drive/proxy/:documentId instead of
+-- being downloaded into our storage. Any document that still has a Drive file
+-- id should be reclassified as storageType='google_drive' with its storageUrl
+-- and storageKey cleared so the viewer routes through the proxy.
+
+UPDATE `data_room_documents`
+SET
+  `storageType` = 'google_drive',
+  `storageUrl` = NULL,
+  `storageKey` = NULL
+WHERE `googleDriveFileId` IS NOT NULL;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -243,6 +243,13 @@
     {
       "idx": 34,
       "version": "5",
+      "when": 1776500000000,
+      "tag": "0034_task_source_external_id",
+      "breakpoints": true
+    },
+    {
+      "idx": 35,
+      "version": "5",
       "when": 1777651200000,
       "tag": "0035_drive_docs_metadata_only",
       "breakpoints": true

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -239,6 +239,13 @@
       "when": 1776400000000,
       "tag": "0033_recipe_copacker_shares",
       "breakpoints": true
+    },
+    {
+      "idx": 34,
+      "version": "5",
+      "when": 1777651200000,
+      "tag": "0035_drive_docs_metadata_only",
+      "breakpoints": true
     }
   ]
 }

--- a/server/_core/googleDrive.ts
+++ b/server/_core/googleDrive.ts
@@ -207,32 +207,23 @@ export async function syncDriveFolder(
   
   async function syncRecursive(currentFolderId: string, depth: number) {
     if (depth > maxDepth) return;
-    
-    // Get subfolders
+
     const { folders, error: folderError } = await listDriveFolders(accessToken, currentFolderId);
     if (folderError) {
       console.error(`[GoogleDrive] Error syncing folder ${currentFolderId}:`, folderError);
       return;
     }
-    
-    // Skip folders named "Private" or starting with "_"
-    const filteredFolders = folders.filter(f =>
-      !f.name.toLowerCase().includes('private') &&
-      !f.name.startsWith('_') &&
-      !f.name.toLowerCase().includes('confidential')
-    );
-    allFolders.push(...filteredFolders);
 
-    // Get files in current folder
+    allFolders.push(...folders);
+
     const { files, error: fileError } = await listDriveFiles(accessToken, currentFolderId);
     if (fileError) {
       console.error(`[GoogleDrive] Error getting files in ${currentFolderId}:`, fileError);
     } else {
       allFiles.push(...files);
     }
-    
-    // Recursively sync subfolders (only non-private ones)
-    for (const folder of filteredFolders) {
+
+    for (const folder of folders) {
       await syncRecursive(folder.id, depth + 1);
     }
   }

--- a/server/routers.ts
+++ b/server/routers.ts
@@ -38,6 +38,7 @@ import { nanoid } from "nanoid";
 import { sendGmailMessage, createGmailDraft, listGmailMessages, getGmailMessage, replyToGmailMessage, getGmailProfile, type GmailSendOptions, type GmailDraftOptions } from "./_core/gmail";
 import { createGoogleDoc, insertTextInDoc, getGoogleDoc, updateGoogleDoc, createGoogleSheet, updateGoogleSheet, appendToGoogleSheet, getGoogleSheetValues, shareGoogleFile, getFileShareableLink } from "./_core/googleWorkspace";
 import { getGoogleFullAccessAuthUrl, syncDriveFolder, listDriveFolders, listDriveFiles, getFileMetadata, getFolderInfo, getSimpleFileType } from "./_core/googleDrive";
+import { getServiceAccountEmail, isServiceAccountConfigured } from "./_core/googleServiceAccount";
 import { getQuickBooksAuthUrl, validateOAuthState, exchangeCodeForToken, refreshQuickBooksToken, getCompanyInfo, getChartOfAccounts, getQuickBooksItems } from "./_core/quickbooks";
 import { listAllTranscripts, getTranscript, extractParticipants, parseActionItems, validateApiKey as validateFirefliesApiKey } from "./_core/fireflies";
 import { queueFirefliesActionItemsForApproval } from "./firefliesSyncService";
@@ -3590,6 +3591,10 @@ ONLY return the JSON array, no other text.`;
           configured: googleConnected,
           status: googleConnected ? 'connected' : 'not_configured',
           email: googleToken?.googleEmail,
+        },
+        googleDriveServiceAccount: {
+          configured: isServiceAccountConfigured(),
+          email: getServiceAccountEmail(),
         },
         quickbooks: {
           configured: quickbooksConnected,


### PR DESCRIPTION
## Summary

The data room viewer was embedding Google Drive's `/preview` URL directly in an iframe. For private folders, Google blocks that iframe and shows "This content is blocked" unless the viewer's browser is signed into a Google account with access — which is never true for public share-link visitors and isn't reliable even for the owner.

This PR replaces the approach with an on-demand **streaming proxy**: our server fetches the file bytes using the data room owner's OAuth token (with an optional service-account fallback) and pipes them straight to the browser. Files never leave Google Drive, and nothing is persisted in our storage.

## What's in it

- **`GET /api/drive/proxy/:documentId`** (`server/_core/index.ts`) — authenticated by data-room ownership or by an active share link via `?linkCode=`. Uses `getValidGoogleToken` + new service-account fallback; streams the response with `Readable.fromWeb(…).pipe(res)`.
- **Service account auth module** (`server/_core/googleServiceAccount.ts`) — RS256-signed JWT via `node:crypto`, tokens cached in memory. Configure via `GOOGLE_SERVICE_ACCOUNT_JSON`.
- **`driveFetch` helper** (`server/_core/googleDrive.ts`) now retries any 401/403 with the service-account token when configured, and error messages include the SA email so users know which address to share folders with.
- **Sync service** (`server/googleDriveSyncService.ts`, auto-sync loop, `redownloadAll`) no longer downloads files. Records are metadata-only with `storageType='google_drive'`. Removed `downloadAndUploadFile`, `storagePut` import, and the `redownloadAll` tRPC mutation.
- **Viewer** (`DataRoomDetail.tsx`, `DataRoomPublic.tsx`) — iframe `src` is now `/api/drive/proxy/:id` (public variant appends `?linkCode=...`).
- **Removed silent folder-name filter** (`googleDrive.ts:184-189`) that was skipping folders containing "private"/"confidential"/"_" with no warning — had been a source of confusion.
- **Settings → Integrations** — new card surfaces whether the service account is configured and, if so, its email address.
- **Migration `0035_drive_docs_metadata_only.sql`** — one-time `UPDATE` to flip existing Drive-synced documents to `storageType='google_drive'` with `storageUrl`/`storageKey` cleared, so the viewer routes through the proxy instead of stale S3 URLs.

## Deploy checklist

- [ ] (Optional) Set `GOOGLE_SERVICE_ACCOUNT_JSON` in Railway and share the data room's Drive folder with the service account email.
- [ ] Deploy / merge. Auto-migration runs `0035_*` at startup.
- [ ] Open a file in the data room viewer — the iframe should load via `/api/drive/proxy/:id`; no "content blocked" screen.
- [ ] If desired, re-run the Drive sync to pick up any previously-filtered "Private"/"confidential" folders that the old filter was skipping.

## Test plan

- [ ] Owner opens a document in their own data room → iframe renders the file content.
- [ ] Share-link viewer (not signed into Google) opens a document → iframe renders the file content.
- [ ] A document whose owner's OAuth token can't reach it (e.g. folder only shared with the service account) still renders when the SA is configured.
- [ ] Non-owner authenticated user hits `/api/drive/proxy/:id` → 403.
- [ ] Expired / inactive share link → 403.
- [ ] Sync runs and creates metadata-only records (no `storageUrl`).

https://claude.ai/code/session_01BWvxEVkbbRBb1KCJ45MJ68

---
_Generated by [Claude Code](https://claude.ai/code/session_01BWvxEVkbbRBb1KCJ45MJ68)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stream Google Drive files through a server proxy so private folders render in the data room without a Google login. Sync is now metadata-only and files are never copied to S3; optional service-account access works as a fallback.

- **New Features**
  - Viewer loads files from `GET /api/drive/proxy/:documentId` using the owner’s OAuth token, with a service‑account fallback; public links pass `?linkCode=...`.
  - Settings → Integrations shows Drive service account status and the email to share with; supports `GOOGLE_SERVICE_ACCOUNT_JSON` or `GOOGLE_SERVICE_ACCOUNT_EMAIL`/`GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY`.
  - Removed the hidden folder-name filter in Drive sync that skipped “private/confidential/_” folders.

- **Migration**
  - `0035_drive_docs_metadata_only.sql` updates existing Drive docs to `storageType='google_drive'` and clears `storageUrl`/`storageKey` so the viewer routes through the proxy.

<sup>Written for commit 0929314b547c0bdbb487049ffff639e6360f07f3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

