### PR TITLE
Consolidate dashboard headers into compact single-row layouts

### DIFF
--- a/client/src/pages/DataRooms.tsx
+++ b/client/src/pages/DataRooms.tsx
@@ -125,14 +125,19 @@ export default function DataRooms() {
   };
 
   return (
-    <div className="p-6 space-y-6">
-        {/* Header */}
-        <div className="flex items-center justify-between">
-          <div>
-            <h1 className="text-lg font-semibold">Data Rooms</h1>
-            <p className="text-muted-foreground mt-1">
-              Securely share documents with granular permissions and analytics
-            </p>
+    <div className="p-6 space-y-2">
+        {/* Header — single consolidated row */}
+        <div className="flex items-center justify-between gap-4 flex-wrap">
+          <div className="flex items-center gap-4 text-xs flex-wrap">
+            <h1 className="text-sm font-bold tracking-[-0.02em]">Data Rooms</h1>
+            <div className="h-4 w-px bg-border" />
+            <div><span className="text-muted-foreground">Total</span> <span className="font-bold">{dataRooms?.length || 0}</span></div>
+            <div className="h-4 w-px bg-border" />
+            <div><span className="text-muted-foreground">Active</span> <span className="font-bold text-green-600">{dataRooms?.filter(r => r.status === 'active').length || 0}</span></div>
+            <div className="h-4 w-px bg-border" />
+            <div><span className="text-muted-foreground">Password</span> <span className="font-bold">{dataRooms?.filter(r => r.password).length || 0}</span></div>
+            <div className="h-4 w-px bg-border" />
+            <div><span className="text-muted-foreground">NDA</span> <span className="font-bold">{dataRooms?.filter(r => r.requiresNda).length || 0}</span></div>
           </div>
           <Dialog open={createDialogOpen} onOpenChange={setCreateDialogOpen}>
             <DialogTrigger asChild>
@@ -280,48 +285,6 @@ export default function DataRooms() {
               </DialogFooter>
             </DialogContent>
           </Dialog>
-        </div>
-
-        {/* Stats Cards */}
-        <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-          <Card>
-            <CardHeader className="pb-2">
-              <CardTitle className="text-sm font-medium text-muted-foreground">Total Rooms</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="text-xl font-semibold tracking-[-0.02em]">{dataRooms?.length || 0}</div>
-            </CardContent>
-          </Card>
-          <Card>
-            <CardHeader className="pb-2">
-              <CardTitle className="text-sm font-medium text-muted-foreground">Active</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="text-xl font-semibold tracking-[-0.02em] text-green-600">
-                {dataRooms?.filter(r => r.status === 'active').length || 0}
-              </div>
-            </CardContent>
-          </Card>
-          <Card>
-            <CardHeader className="pb-2">
-              <CardTitle className="text-sm font-medium text-muted-foreground">Password Protected</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="text-xl font-semibold tracking-[-0.02em]">
-                {dataRooms?.filter(r => r.password).length || 0}
-              </div>
-            </CardContent>
-          </Card>
-          <Card>
-            <CardHeader className="pb-2">
-              <CardTitle className="text-sm font-medium text-muted-foreground">NDA Required</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="text-xl font-semibold tracking-[-0.02em]">
-                {dataRooms?.filter(r => r.requiresNda).length || 0}
-              </div>
-            </CardContent>
-          </Card>
         </div>
 
         {/* Data Rooms List */}

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -251,7 +251,7 @@ export default function Home() {
     <div className="space-y-2 animate-fade-in">
       {/* Header */}
       <div className="flex items-center justify-between">
-        <h1 className="text-lg font-semibold">Dashboard</h1>
+        <h1 className="text-sm font-bold tracking-[-0.02em]">Dashboard</h1>
       </div>
 
       {/* Row 1 — Financial Health */}

--- a/client/src/pages/Meetings.tsx
+++ b/client/src/pages/Meetings.tsx
@@ -242,7 +242,7 @@ export default function Meetings() {
     <div className="space-y-2">
       {/* ── Compact toolbar: stats + search + actions ── */}
       <div className="flex flex-wrap items-center gap-2">
-        <h1 className="text-lg font-semibold tracking-tight mr-1">Meetings</h1>
+        <h1 className="text-sm font-bold tracking-[-0.02em] mr-1">Meetings</h1>
         <div className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
           <span className="rounded bg-muted px-1.5 py-0.5 font-medium tabular-nums">{stats?.total ?? meetings.length}</span>
           <span className="rounded bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400 px-1.5 py-0.5 font-medium tabular-nums">{stats?.pending ?? 0} pending</span>

--- a/client/src/pages/Messaging.tsx
+++ b/client/src/pages/Messaging.tsx
@@ -216,15 +216,10 @@ export default function Messaging() {
   // ----- Render -----
 
   return (
-    <div className="animate-fade-in space-y-6">
-      {/* Page Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-lg font-semibold">Messaging</h1>
-          <p className="text-muted-foreground text-sm mt-1">
-            Unified conversations across WhatsApp, Email, and Google Chat
-          </p>
-        </div>
+    <div className="animate-fade-in space-y-2">
+      {/* Header — single consolidated row */}
+      <div className="flex items-center justify-between gap-3 flex-wrap">
+        <h1 className="text-sm font-bold tracking-[-0.02em]">Messaging</h1>
         <div className="flex items-center gap-2">
           <Badge variant="outline" className="gap-1.5">
             <Wifi className="h-3 w-3 text-green-500" />

--- a/client/src/pages/Projects.tsx
+++ b/client/src/pages/Projects.tsx
@@ -890,18 +890,13 @@ export default function Projects() {
   };
 
   return (
-    <div className="p-6 space-y-6 animate-fade-in">
-        {/* Header */}
-        <div className="flex items-center justify-between">
-          <div>
-            <h1 className="text-lg font-semibold flex items-center gap-2">
-              <FolderKanban className="h-4 w-4" />
-              Projects & Tasks
-            </h1>
-            <p className="text-muted-foreground mt-1">
-              Manage tasks with Kanban or Spreadsheet view
-            </p>
-          </div>
+    <div className="p-6 space-y-2 animate-fade-in">
+        {/* Header — single consolidated row */}
+        <div className="flex items-center justify-between gap-3 flex-wrap">
+          <h1 className="text-sm font-bold tracking-[-0.02em] flex items-center gap-1.5">
+            <FolderKanban className="h-4 w-4" />
+            Projects & Tasks
+          </h1>
           <div className="flex items-center gap-2">
             {/* View toggle */}
             <div className="flex items-center border rounded-lg p-1">

--- a/client/src/pages/SOPs.tsx
+++ b/client/src/pages/SOPs.tsx
@@ -948,13 +948,11 @@ export default function SOPs() {
   };
 
   return (
-    <div className="space-y-3 animate-fade-in">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-lg font-semibold">SOPs</h1>
-          <p className="text-muted-foreground text-sm">{sops.length} procedures — select to expand</p>
-        </div>
+    <div className="space-y-2 animate-fade-in">
+      {/* Header — single consolidated row */}
+      <div className="flex items-center gap-3 flex-wrap">
+        <h1 className="text-sm font-bold tracking-[-0.02em]">SOPs</h1>
+        <span className="text-xs text-muted-foreground">{sops.length} procedures</span>
       </div>
 
       {/* Search & Filter Bar */}

--- a/client/src/pages/crm/CRMHub.tsx
+++ b/client/src/pages/crm/CRMHub.tsx
@@ -323,12 +323,27 @@ export default function CRMHub() {
     );
   }, [enrichedDeals, dealsSearch]);
 
+  const openVal = Number(dealStats?.openValue || 0);
+  const wonVal = Number(dealStats?.wonValue || 0);
+  const totalDeals = (dealStats?.open || 0) + (dealStats?.won || 0) + (dealStats?.lost || 0);
+  const conversionRate = totalDeals > 0 ? Math.round(((dealStats?.won || 0) / totalDeals) * 100) : 0;
+
   return (
     <div className="space-y-2 animate-fade-in">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-xl font-bold tracking-[-0.02em]">CRM Hub</h1>
+      {/* Header — single consolidated row */}
+      <div className="flex items-center justify-between gap-4 flex-wrap">
+        <div className="flex items-center gap-4 text-xs flex-wrap">
+          <h1 className="text-sm font-bold tracking-[-0.02em]">CRM Hub</h1>
+          <div className="h-4 w-px bg-border" />
+          <div><span className="text-muted-foreground">Pipeline</span> <span className="font-bold">${openVal.toLocaleString()}</span></div>
+          <div className="h-4 w-px bg-border" />
+          <div><span className="text-muted-foreground">Won</span> <span className="font-bold text-green-600">${wonVal.toLocaleString()}</span></div>
+          <div className="h-4 w-px bg-border" />
+          <div><span className="text-muted-foreground">Open</span> <span className="font-bold">{dealStats?.open || 0}</span></div>
+          <div className="h-4 w-px bg-border" />
+          <div><span className="text-muted-foreground">Win Rate</span> <span className="font-bold">{conversionRate}%</span></div>
+          <div className="h-4 w-px bg-border" />
+          <div><span className="text-muted-foreground">Contacts</span> <span className="font-bold">{contactStats?.total || 0}</span></div>
         </div>
         <div className="flex gap-2">
           <Button
@@ -692,27 +707,6 @@ export default function CRMHub() {
           </Dialog>
         </div>
       </div>
-
-      {/* Sales KPIs — compact bar */}
-      {(() => {
-        const openVal = Number(dealStats?.openValue || 0);
-        const wonVal = Number(dealStats?.wonValue || 0);
-        const totalDeals = (dealStats?.open || 0) + (dealStats?.won || 0) + (dealStats?.lost || 0);
-        const conversionRate = totalDeals > 0 ? Math.round(((dealStats?.won || 0) / totalDeals) * 100) : 0;
-        return (
-          <div className="flex items-center gap-4 text-xs border rounded-xl px-3 py-2 bg-card">
-            <div><span className="text-muted-foreground">Pipeline</span> <span className="font-bold">${openVal.toLocaleString()}</span></div>
-            <div className="h-5 w-px bg-border" />
-            <div><span className="text-muted-foreground">Won</span> <span className="font-bold text-green-600">${wonVal.toLocaleString()}</span></div>
-            <div className="h-5 w-px bg-border" />
-            <div><span className="text-muted-foreground">Open</span> <span className="font-bold">{dealStats?.open || 0}</span></div>
-            <div className="h-5 w-px bg-border" />
-            <div><span className="text-muted-foreground">Win Rate</span> <span className="font-bold">{conversionRate}%</span></div>
-            <div className="h-5 w-px bg-border" />
-            <div><span className="text-muted-foreground">Contacts</span> <span className="font-bold">{contactStats?.total || 0}</span></div>
-          </div>
-        );
-      })()}
 
       {/* Deals Table */}
       <Card className="py-3">

--- a/client/src/pages/edi/EDIDashboard.tsx
+++ b/client/src/pages/edi/EDIDashboard.tsx
@@ -82,107 +82,38 @@ export default function EDIDashboard() {
   }
 
   return (
-    <div className="p-6 space-y-6">
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-xl font-semibold tracking-[-0.02em]">EDI Hub</h1>
-          <p className="text-muted-foreground">Electronic Data Interchange for retail customer connections</p>
+    <div className="p-6 space-y-2">
+      {/* Header — single consolidated row */}
+      <div className="flex items-center justify-between gap-4 flex-wrap">
+        <div className="flex items-center gap-4 text-xs flex-wrap">
+          <h1 className="text-sm font-bold tracking-[-0.02em]">EDI</h1>
+          <div className="h-4 w-px bg-border" />
+          <div><span className="text-muted-foreground">Partners</span> <span className="font-bold">{stats?.totalPartners || 0}</span></div>
+          <div className="h-4 w-px bg-border" />
+          <div><span className="text-muted-foreground">Active</span> <span className="font-bold text-green-600">{stats?.activePartners || 0}</span></div>
+          <div className="h-4 w-px bg-border" />
+          <div><span className="text-muted-foreground">Transactions</span> <span className="font-bold">{stats?.totalTransactions || 0}</span></div>
+          <div className="h-4 w-px bg-border" />
+          <div><span className="text-muted-foreground">This Week</span> <span className="font-bold">{stats?.recentTransactions || 0}</span></div>
+          <div className="h-4 w-px bg-border" />
+          <div><span className="text-muted-foreground">Pending</span> <span className="font-bold">{(stats as any)?.pendingAcks || 0}</span></div>
+          <div className="h-4 w-px bg-border" />
+          <div><span className="text-muted-foreground">Errors</span> <span className="font-bold text-red-600">{(stats as any)?.errorTransactions || 0}</span></div>
         </div>
         <div className="flex gap-2">
           <Link href="/edi/partners">
-            <Button variant="outline">
+            <Button variant="outline" size="sm">
               <Building2 className="h-4 w-4 mr-2" />
               Trading Partners
             </Button>
           </Link>
           <Link href="/edi/connect">
-            <Button>
+            <Button size="sm">
               <Plus className="h-4 w-4 mr-2" />
               Connect a Retailer
             </Button>
           </Link>
         </div>
-      </div>
-
-      {/* Stats Grid */}
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-6 gap-4">
-        <Card>
-          <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium text-muted-foreground flex items-center gap-2">
-              <Building2 className="h-4 w-4" />
-              Partners
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="text-xl font-semibold tracking-[-0.02em]">{stats?.totalPartners || 0}</div>
-            <p className="text-xs text-muted-foreground">{stats?.activePartners || 0} active</p>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium text-muted-foreground flex items-center gap-2">
-              <ArrowLeftRight className="h-4 w-4" />
-              Total Transactions
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="text-xl font-semibold tracking-[-0.02em]">{stats?.totalTransactions || 0}</div>
-            <p className="text-xs text-muted-foreground">All time</p>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium text-muted-foreground flex items-center gap-2">
-              <FileText className="h-4 w-4" />
-              This Week
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="text-xl font-semibold tracking-[-0.02em]">{stats?.recentTransactions || 0}</div>
-            <p className="text-xs text-muted-foreground">Last 7 days</p>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium text-muted-foreground flex items-center gap-2">
-              <Clock className="h-4 w-4" />
-              Pending ACKs
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="text-xl font-semibold tracking-[-0.02em]">{(stats as any)?.pendingAcks || 0}</div>
-            <p className="text-xs text-muted-foreground">Awaiting response</p>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium text-muted-foreground flex items-center gap-2">
-              <AlertTriangle className="h-4 w-4" />
-              Errors
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="text-xl font-semibold tracking-[-0.02em] text-red-600">{(stats as any)?.errorTransactions || 0}</div>
-            <p className="text-xs text-muted-foreground">Needs attention</p>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium text-muted-foreground flex items-center gap-2">
-              <CheckCircle2 className="h-4 w-4" />
-              Active Partners
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="text-xl font-semibold tracking-[-0.02em] text-green-600">{stats?.activePartners || 0}</div>
-            <p className="text-xs text-muted-foreground">Connected</p>
-          </CardContent>
-        </Card>
       </div>
 
       {/* Quick Actions & Document Flow */}

--- a/client/src/pages/finance/FinanceHub.tsx
+++ b/client/src/pages/finance/FinanceHub.tsx
@@ -19,19 +19,14 @@ export default function FinanceHub() {
   const [tab, setTab] = useState("ledger");
 
   return (
-    <div className="space-y-4 animate-fade-in">
-      <div>
-        <h1 className="text-lg font-semibold flex items-center gap-2">
-          <DollarSign className="h-8 w-8" />
-          Finance
-        </h1>
-        <p className="text-muted-foreground mt-1">
-          Accounts, transactions, reports, CFO strategy, and R&D tax credits
-        </p>
-      </div>
-
+    <div className="space-y-2 animate-fade-in">
       <Tabs value={tab} onValueChange={setTab}>
-        <TabsList>
+        <div className="flex items-center gap-3 flex-wrap">
+          <h1 className="text-sm font-bold tracking-[-0.02em] flex items-center gap-1.5">
+            <DollarSign className="h-4 w-4" />
+            Finance
+          </h1>
+          <TabsList>
           <TabsTrigger value="ledger" className="flex items-center gap-1.5">
             <DollarSign className="h-4 w-4" />
             Accounts & Transactions
@@ -49,6 +44,7 @@ export default function FinanceHub() {
             R&D Tax Credit
           </TabsTrigger>
         </TabsList>
+        </div>
 
         <TabsContent value="ledger">
           <Suspense fallback={fallback}><AccountsAndTransactions /></Suspense>

--- a/client/src/pages/grants/GrantBidSubmitter.tsx
+++ b/client/src/pages/grants/GrantBidSubmitter.tsx
@@ -109,21 +109,28 @@ export default function GrantBidSubmitter() {
   }
 
   return (
-    <div className="space-y-6 p-6">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl font-bold flex items-center gap-2">
-            <ClipboardCheck className="h-6 w-6 text-primary" />
-            Grant & Bid Submitter
+    <div className="space-y-2 p-6">
+      {/* Header — single consolidated row */}
+      <div className="flex items-center justify-between gap-4 flex-wrap">
+        <div className="flex items-center gap-4 text-xs flex-wrap">
+          <h1 className="text-sm font-bold tracking-[-0.02em] flex items-center gap-1.5">
+            <ClipboardCheck className="h-4 w-4 text-primary" />
+            Grants & Bids
           </h1>
-          <p className="text-muted-foreground mt-1">
-            Discover opportunities, then auto-generate applications powered by AI
-          </p>
+          <div className="h-4 w-px bg-border" />
+          <div><span className="text-muted-foreground">Total</span> <span className="font-bold">{stats?.total || 0}</span></div>
+          <div className="h-4 w-px bg-border" />
+          <div><span className="text-muted-foreground">Draft</span> <span className="font-bold text-amber-600">{stats?.draft || 0}</span></div>
+          <div className="h-4 w-px bg-border" />
+          <div><span className="text-muted-foreground">Submitted</span> <span className="font-bold text-indigo-600">{stats?.submitted || 0}</span></div>
+          <div className="h-4 w-px bg-border" />
+          <div><span className="text-muted-foreground">Awarded</span> <span className="font-bold text-green-600">{stats?.awarded || 0}</span></div>
+          <div className="h-4 w-px bg-border" />
+          <div><span className="text-muted-foreground">Requested</span> <span className="font-bold text-emerald-600">{formatCurrency(stats?.totalRequested)}</span></div>
         </div>
         <Dialog open={showCreate} onOpenChange={setShowCreate}>
           <DialogTrigger asChild>
-            <Button><Plus className="h-4 w-4 mr-2" /> New Application</Button>
+            <Button size="sm"><Plus className="h-4 w-4 mr-2" /> New Application</Button>
           </DialogTrigger>
           <CreateApplicationDialog onClose={() => setShowCreate(false)} onCreated={(id) => { setShowCreate(false); setSelectedApp(id); refetchApps(); }} />
         </Dialog>
@@ -146,66 +153,7 @@ export default function GrantBidSubmitter() {
         </TabsContent>
 
         {/* Applications Tab */}
-        <TabsContent value="applications" className="space-y-6">
-          {/* Stats Cards */}
-          <div className="grid grid-cols-1 md:grid-cols-5 gap-4">
-            <Card>
-              <CardContent className="p-4">
-                <div className="flex items-center gap-3">
-                  <div className="p-2 rounded-lg bg-blue-500/10"><FileText className="h-5 w-5 text-blue-600" /></div>
-                  <div>
-                    <p className="text-sm text-muted-foreground">Total</p>
-                    <p className="text-2xl font-bold">{stats?.total || 0}</p>
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
-            <Card>
-              <CardContent className="p-4">
-                <div className="flex items-center gap-3">
-                  <div className="p-2 rounded-lg bg-amber-500/10"><Edit className="h-5 w-5 text-amber-600" /></div>
-                  <div>
-                    <p className="text-sm text-muted-foreground">In Progress</p>
-                    <p className="text-2xl font-bold">{stats?.draft || 0}</p>
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
-            <Card>
-              <CardContent className="p-4">
-                <div className="flex items-center gap-3">
-                  <div className="p-2 rounded-lg bg-indigo-500/10"><Send className="h-5 w-5 text-indigo-600" /></div>
-                  <div>
-                    <p className="text-sm text-muted-foreground">Submitted</p>
-                    <p className="text-2xl font-bold">{stats?.submitted || 0}</p>
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
-            <Card>
-              <CardContent className="p-4">
-                <div className="flex items-center gap-3">
-                  <div className="p-2 rounded-lg bg-green-500/10"><CheckCircle2 className="h-5 w-5 text-green-600" /></div>
-                  <div>
-                    <p className="text-sm text-muted-foreground">Awarded</p>
-                    <p className="text-2xl font-bold">{stats?.awarded || 0}</p>
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
-            <Card>
-              <CardContent className="p-4">
-                <div className="flex items-center gap-3">
-                  <div className="p-2 rounded-lg bg-emerald-500/10"><DollarSign className="h-5 w-5 text-emerald-600" /></div>
-                  <div>
-                    <p className="text-sm text-muted-foreground">Total Requested</p>
-                    <p className="text-lg font-bold">{formatCurrency(stats?.totalRequested)}</p>
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
-          </div>
-
+        <TabsContent value="applications" className="space-y-2">
           {/* Filters */}
           <div className="flex gap-3 items-center">
             <div className="relative flex-1 max-w-sm">

--- a/client/src/pages/hr/Employees.tsx
+++ b/client/src/pages/hr/Employees.tsx
@@ -524,18 +524,13 @@ export default function PeopleAndEquity() {
 
   // ══════════════════════════════════════════════════════════════════
   return (
-    <div className="space-y-6 animate-fade-in">
-      {/* Header */}
+    <div className="space-y-2 animate-fade-in">
+      {/* Header — single consolidated row */}
       <div className="flex items-center justify-between flex-wrap gap-3">
-        <div>
-          <h1 className="text-lg font-semibold flex items-center gap-2">
-            <UserCircle className="h-8 w-8" />
-            People
-          </h1>
-          <p className="text-muted-foreground mt-1">
-            Team members, investors, advisors, and equity holdings
-          </p>
-        </div>
+        <h1 className="text-sm font-bold tracking-[-0.02em] flex items-center gap-1.5">
+          <UserCircle className="h-4 w-4" />
+          People
+        </h1>
         <div className="flex items-center gap-2">
           <Button variant="outline" onClick={() => window.location.href = "/hr/me"}>
             <UserCircle className="h-4 w-4 mr-1" /> My Portal

--- a/client/src/pages/hr/InvestorsHub.tsx
+++ b/client/src/pages/hr/InvestorsHub.tsx
@@ -17,20 +17,21 @@ export default function InvestorsHub() {
   const [tab, setTab] = useState("captable");
 
   return (
-    <div className="space-y-3 animate-fade-in">
-      <h1 className="text-xl font-bold tracking-[-0.02em]">Investors</h1>
-
+    <div className="space-y-2 animate-fade-in">
       <Tabs value={tab} onValueChange={setTab}>
-        <TabsList>
-          <TabsTrigger value="captable" className="flex items-center gap-1.5">
-            <FileBarChart className="h-3.5 w-3.5" />
-            Cap Table
-          </TabsTrigger>
-          <TabsTrigger value="updates" className="flex items-center gap-1.5">
-            <Megaphone className="h-3.5 w-3.5" />
-            Investor Updates
-          </TabsTrigger>
-        </TabsList>
+        <div className="flex items-center gap-3 flex-wrap">
+          <h1 className="text-sm font-bold tracking-[-0.02em]">Investors</h1>
+          <TabsList>
+            <TabsTrigger value="captable" className="flex items-center gap-1.5">
+              <FileBarChart className="h-3.5 w-3.5" />
+              Cap Table
+            </TabsTrigger>
+            <TabsTrigger value="updates" className="flex items-center gap-1.5">
+              <Megaphone className="h-3.5 w-3.5" />
+              Investor Updates
+            </TabsTrigger>
+          </TabsList>
+        </div>
 
         <TabsContent value="captable">
           <Suspense fallback={fallback}><EquityReports /></Suspense>

--- a/client/src/pages/hr/Recruiting.tsx
+++ b/client/src/pages/hr/Recruiting.tsx
@@ -122,13 +122,20 @@ Provide: 1) Score X/10, 2) Key strengths, 3) Concerns, 4) Recommendation (advanc
   };
 
   return (
-    <div className="space-y-3 animate-fade-in">
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-xl font-bold tracking-[-0.02em] flex items-center gap-2">
-            <UserPlus className="h-6 w-6" /> Recruiting
+    <div className="space-y-2 animate-fade-in">
+      <div className="flex items-center justify-between gap-4 flex-wrap">
+        <div className="flex items-center gap-4 text-xs flex-wrap">
+          <h1 className="text-sm font-bold tracking-[-0.02em] flex items-center gap-1.5">
+            <UserPlus className="h-4 w-4" /> Recruiting
           </h1>
-          <p className="text-muted-foreground text-sm">Candidates, AI scoring, and interview scheduling</p>
+          <div className="h-4 w-px bg-border" />
+          <div><span className="text-muted-foreground">Pipeline</span> <span className="font-bold">{stats.pipeline}</span></div>
+          <div className="h-4 w-px bg-border" />
+          <div><span className="text-muted-foreground">Interviews</span> <span className="font-bold">{stats.interviews}</span></div>
+          <div className="h-4 w-px bg-border" />
+          <div><span className="text-muted-foreground">Offers</span> <span className="font-bold text-green-600">{stats.offers}</span></div>
+          <div className="h-4 w-px bg-border" />
+          <div><span className="text-muted-foreground">Total</span> <span className="font-bold">{stats.total}</span></div>
         </div>
         <Dialog open={isOpen} onOpenChange={setIsOpen}>
           <DialogTrigger asChild>
@@ -168,17 +175,6 @@ Provide: 1) Score X/10, 2) Key strengths, 3) Concerns, 4) Recommendation (advanc
             </DialogFooter>
           </DialogContent>
         </Dialog>
-      </div>
-
-      {/* KPI bar */}
-      <div className="flex items-center gap-4 text-xs border rounded-xl px-3 py-2 bg-card">
-        <div><span className="text-muted-foreground">Pipeline</span> <span className="font-bold">{stats.pipeline}</span></div>
-        <div className="h-5 w-px bg-border" />
-        <div><span className="text-muted-foreground">Interviews</span> <span className="font-bold">{stats.interviews}</span></div>
-        <div className="h-5 w-px bg-border" />
-        <div><span className="text-muted-foreground">Offers</span> <span className="font-bold text-green-600">{stats.offers}</span></div>
-        <div className="h-5 w-px bg-border" />
-        <div><span className="text-muted-foreground">Total</span> <span className="font-bold">{stats.total}</span></div>
       </div>
 
       {/* Filters */}

--- a/client/src/pages/legal/LegalHub.tsx
+++ b/client/src/pages/legal/LegalHub.tsx
@@ -22,19 +22,14 @@ export default function LegalHub() {
   const [tab, setTab] = useState(defaultTab);
 
   return (
-    <div className="space-y-4 animate-fade-in">
-      <div>
-        <h1 className="text-lg font-semibold flex items-center gap-2">
-          <Scale className="h-8 w-8" />
-          Legal
-        </h1>
-        <p className="text-muted-foreground mt-1">
-          Contracts, cases, and legal documents
-        </p>
-      </div>
-
+    <div className="space-y-2 animate-fade-in">
       <Tabs value={tab} onValueChange={setTab}>
-        <TabsList>
+        <div className="flex items-center gap-3 flex-wrap">
+          <h1 className="text-sm font-bold tracking-[-0.02em] flex items-center gap-1.5">
+            <Scale className="h-4 w-4" />
+            Legal
+          </h1>
+          <TabsList>
           <TabsTrigger value="contracts" className="flex items-center gap-1.5">
             <FileText className="h-4 w-4" />
             Contracts
@@ -48,6 +43,7 @@ export default function LegalHub() {
             Documents
           </TabsTrigger>
         </TabsList>
+        </div>
 
         <TabsContent value="contracts">
           <Suspense fallback={fallback}><Contracts /></Suspense>

--- a/client/src/pages/marketing/ContentHub.tsx
+++ b/client/src/pages/marketing/ContentHub.tsx
@@ -89,21 +89,17 @@ export default function ContentHub() {
   };
 
   return (
-    <div className="space-y-3 animate-fade-in">
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-xl font-bold tracking-[-0.02em] flex items-center gap-2">
-            <PenTool className="h-6 w-6" /> Marketing & Content
-          </h1>
-          <p className="text-muted-foreground text-sm">AI content creation, SEO, social media</p>
-        </div>
-      </div>
-
+    <div className="space-y-2 animate-fade-in">
       <Tabs value={tab} onValueChange={setTab}>
-        <TabsList>
-          <TabsTrigger value="create">Create Content</TabsTrigger>
-          <TabsTrigger value="saved">Saved ({savedContent.length})</TabsTrigger>
-        </TabsList>
+        <div className="flex items-center gap-3 flex-wrap">
+          <h1 className="text-sm font-bold tracking-[-0.02em] flex items-center gap-1.5">
+            <PenTool className="h-4 w-4" /> Marketing & Content
+          </h1>
+          <TabsList>
+            <TabsTrigger value="create">Create Content</TabsTrigger>
+            <TabsTrigger value="saved">Saved ({savedContent.length})</TabsTrigger>
+          </TabsList>
+        </div>
 
         <TabsContent value="create" className="space-y-3">
           <Card>

--- a/client/src/pages/operations/LogisticsHub.tsx
+++ b/client/src/pages/operations/LogisticsHub.tsx
@@ -347,42 +347,23 @@ export default function LogisticsHub() {
     : Package;
 
   return (
-    <div className="p-6 space-y-6 animate-fade-in">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-lg font-semibold flex items-center gap-2">
-            <Truck className="h-8 w-8" />
-            Logistics Hub
-          </h1>
-          <p className="text-muted-foreground mt-1">
-            Shipments with customs status — click any row to open details
-          </p>
-        </div>
-      </div>
-
-      {/* Stats */}
-      <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
-        <Card className="p-4">
-          <div className="text-xl font-semibold tracking-[-0.02em]">{stats.totalShipments}</div>
-          <div className="text-xs text-muted-foreground">Total Shipments</div>
-        </Card>
-        <Card className="p-4">
-          <div className="text-xl font-semibold tracking-[-0.02em] text-amber-600">{stats.pending}</div>
-          <div className="text-xs text-muted-foreground">Pending</div>
-        </Card>
-        <Card className="p-4">
-          <div className="text-xl font-semibold tracking-[-0.02em] text-blue-600">{stats.inTransit}</div>
-          <div className="text-xs text-muted-foreground">In Transit</div>
-        </Card>
-        <Card className="p-4">
-          <div className="text-xl font-semibold tracking-[-0.02em] text-orange-600">{stats.inCustoms}</div>
-          <div className="text-xs text-muted-foreground">In Customs</div>
-        </Card>
-        <Card className="p-4">
-          <div className="text-xl font-semibold tracking-[-0.02em] text-green-600">{stats.delivered}</div>
-          <div className="text-xs text-muted-foreground">Delivered</div>
-        </Card>
+    <div className="p-6 space-y-2 animate-fade-in">
+      {/* Header — single consolidated row */}
+      <div className="flex items-center gap-4 text-xs flex-wrap">
+        <h1 className="text-sm font-bold tracking-[-0.02em] flex items-center gap-1.5">
+          <Truck className="h-4 w-4" />
+          Logistics
+        </h1>
+        <div className="h-4 w-px bg-border" />
+        <div><span className="text-muted-foreground">Total</span> <span className="font-bold">{stats.totalShipments}</span></div>
+        <div className="h-4 w-px bg-border" />
+        <div><span className="text-muted-foreground">Pending</span> <span className="font-bold text-amber-600">{stats.pending}</span></div>
+        <div className="h-4 w-px bg-border" />
+        <div><span className="text-muted-foreground">In Transit</span> <span className="font-bold text-blue-600">{stats.inTransit}</span></div>
+        <div className="h-4 w-px bg-border" />
+        <div><span className="text-muted-foreground">Customs</span> <span className="font-bold text-orange-600">{stats.inCustoms}</span></div>
+        <div className="h-4 w-px bg-border" />
+        <div><span className="text-muted-foreground">Delivered</span> <span className="font-bold text-green-600">{stats.delivered}</span></div>
       </div>
 
       {/* Shipments table — row click opens side-sheet */}

--- a/client/src/pages/operations/OperationsHub.tsx
+++ b/client/src/pages/operations/OperationsHub.tsx
@@ -24,29 +24,25 @@ export default function OperationsHub() {
   const [activeTab, setActiveTab] = useState("inventory");
 
   return (
-    <div className="space-y-4">
-      <div>
-        <h1 className="text-lg font-semibold">Operations Hub</h1>
-        <p className="text-sm text-muted-foreground">
-          Procurement, Manufacturing, and Inventory Management
-        </p>
-      </div>
-
+    <div className="space-y-2">
       <Tabs value={activeTab} onValueChange={setActiveTab}>
-        <TabsList className="grid w-full grid-cols-3">
-          <TabsTrigger value="inventory" className="gap-2">
-            <Warehouse className="h-4 w-4" />
-            Inventory
-          </TabsTrigger>
-          <TabsTrigger value="manufacturing" className="gap-2">
-            <Factory className="h-4 w-4" />
-            Manufacturing
-          </TabsTrigger>
-          <TabsTrigger value="procurement" className="gap-2">
-            <Building2 className="h-4 w-4" />
-            Procurement
-          </TabsTrigger>
-        </TabsList>
+        <div className="flex items-center gap-3 flex-wrap">
+          <h1 className="text-sm font-bold tracking-[-0.02em]">Operations</h1>
+          <TabsList>
+            <TabsTrigger value="inventory" className="gap-2">
+              <Warehouse className="h-4 w-4" />
+              Inventory
+            </TabsTrigger>
+            <TabsTrigger value="manufacturing" className="gap-2">
+              <Factory className="h-4 w-4" />
+              Manufacturing
+            </TabsTrigger>
+            <TabsTrigger value="procurement" className="gap-2">
+              <Building2 className="h-4 w-4" />
+              Procurement
+            </TabsTrigger>
+          </TabsList>
+        </div>
 
         <TabsContent value="inventory">
           <Suspense fallback={<PageLoader />}>

--- a/client/src/pages/operations/Recipes.tsx
+++ b/client/src/pages/operations/Recipes.tsx
@@ -107,12 +107,9 @@ export default function Recipes() {
   }, [shares]);
 
   return (
-    <div className="p-6 space-y-6">
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-xl font-semibold tracking-[-0.02em]">Recipe Costing</h1>
-          <p className="text-muted-foreground">Manage formulations, batch costing, and yield-adjusted costs</p>
-        </div>
+    <div className="p-6 space-y-2">
+      <div className="flex items-center justify-between gap-3 flex-wrap">
+        <h1 className="text-sm font-bold tracking-[-0.02em]">Recipes</h1>
         <Dialog open={createOpen} onOpenChange={setCreateOpen}>
           <DialogTrigger asChild>
             <Button>

--- a/client/src/pages/operations/Vendors.tsx
+++ b/client/src/pages/operations/Vendors.tsx
@@ -314,17 +314,12 @@ export default function Vendors() {
   const isLoading = vendorsLoading;
 
   return (
-    <div className="space-y-6 animate-fade-in">
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-lg font-semibold flex items-center gap-2">
-            <Building2 className="h-8 w-8" />
-            Vendors
-          </h1>
-          <p className="text-muted-foreground mt-1">
-            Manage suppliers and service providers.
-          </p>
-        </div>
+    <div className="space-y-2 animate-fade-in">
+      <div className="flex items-center justify-between gap-3 flex-wrap">
+        <h1 className="text-sm font-bold tracking-[-0.02em] flex items-center gap-1.5">
+          <Building2 className="h-4 w-4" />
+          Vendors
+        </h1>
         <div className="flex gap-2">
         <Button variant="outline" onClick={() => window.location.href = "/import"}>
           <Upload className="h-4 w-4 mr-1" /> Import

--- a/client/src/pages/sales/FundraisingCampaigns.tsx
+++ b/client/src/pages/sales/FundraisingCampaigns.tsx
@@ -164,12 +164,9 @@ export default function FundraisingCampaigns() {
   // No round yet — show create prompt
   if (!round) {
     return (
-      <div className="space-y-6 animate-fade-in">
-        <div className="flex items-center justify-between">
-          <div>
-            <h1 className="text-lg font-semibold">Fundraising</h1>
-            <p className="text-muted-foreground">Set up your current fundraising round</p>
-          </div>
+      <div className="space-y-2 animate-fade-in">
+        <div className="flex items-center justify-between gap-3 flex-wrap">
+          <h1 className="text-sm font-bold tracking-[-0.02em]">Fundraising</h1>
           {createDialog}
         </div>
         <Card>
@@ -193,18 +190,18 @@ export default function FundraisingCampaigns() {
   const valuation = parseFloat(round.valuation || "0");
 
   return (
-    <div className="space-y-4 animate-fade-in">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-lg font-semibold">Fundraising</h1>
-          <p className="text-muted-foreground text-sm">{round.name}</p>
-        </div>
-        <div className="flex items-center gap-2">
+    <div className="space-y-2 animate-fade-in">
+      {/* Header — single consolidated row */}
+      <div className="flex items-center justify-between gap-3 flex-wrap">
+        <div className="flex items-center gap-3 text-xs flex-wrap">
+          <h1 className="text-sm font-bold tracking-[-0.02em]">Fundraising</h1>
+          <span className="text-muted-foreground">{round.name}</span>
           <Badge className={statusColors[round.status] || statusColors.planning}>
             {round.status}
           </Badge>
           <Badge variant="outline" className="capitalize">{(round.roundType || "seed").replace(/_/g, " ")}</Badge>
+        </div>
+        <div className="flex items-center gap-2">
           {createDialog}
         </div>
       </div>

--- a/client/src/pages/sales/SalesHub.tsx
+++ b/client/src/pages/sales/SalesHub.tsx
@@ -6,7 +6,7 @@ import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { toast } from "sonner";
 import {
-  ShoppingCart, FileText, Users, CreditCard, Package, Search,
+  ShoppingCart, Users, Package, Search,
   ShoppingBag, Plug, Loader2, Mail, CloudUpload, RefreshCw,
   ArrowUpDown, ChevronUp, ChevronDown,
 } from "lucide-react";
@@ -385,12 +385,21 @@ export default function SalesHub() {
   }
 
   return (
-    <div className="p-6 space-y-4">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-lg font-semibold">Orders &amp; Sales</h1>
-          <p className="text-muted-foreground">Unified view of orders, invoices, payments, and shipments</p>
+    <div className="p-6 space-y-2">
+      {/* Header — single consolidated row */}
+      <div className="flex items-center justify-between gap-4 flex-wrap">
+        <div className="flex items-center gap-4 text-xs flex-wrap">
+          <h1 className="text-sm font-bold tracking-[-0.02em]">Orders &amp; Sales</h1>
+          <div className="h-4 w-px bg-border" />
+          <div><span className="text-muted-foreground">Revenue</span> <span className="font-bold text-green-600">${stats.totalRevenue.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</span></div>
+          <div className="h-4 w-px bg-border" />
+          <div><span className="text-muted-foreground">Orders</span> <span className="font-bold">{stats.totalOrders}</span></div>
+          <div className="h-4 w-px bg-border" />
+          <div><span className="text-muted-foreground">Pending</span> <span className="font-bold text-amber-600">{stats.pendingOrders}</span></div>
+          <div className="h-4 w-px bg-border" />
+          <div><span className="text-muted-foreground">Unpaid</span> <span className="font-bold text-red-600">{stats.unpaidInvoices}</span></div>
+          <div className="h-4 w-px bg-border" />
+          <div><span className="text-muted-foreground">Customers</span> <span className="font-bold">{stats.totalCustomers}</span></div>
         </div>
 
         <div className="flex items-center gap-2">
@@ -480,50 +489,6 @@ export default function SalesHub() {
             </DropdownMenuContent>
           </DropdownMenu>
         </div>
-      </div>
-
-      {/* KPI Cards */}
-      <div className="grid grid-cols-5 gap-4">
-        <Card>
-          <CardContent className="pt-4">
-            <div className="flex items-center justify-between">
-              <div><p className="text-sm text-muted-foreground">Revenue</p><p className="text-xl font-semibold tracking-[-0.02em] text-green-600">${stats.totalRevenue.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</p></div>
-              <CreditCard className="h-8 w-8 text-green-500" />
-            </div>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent className="pt-4">
-            <div className="flex items-center justify-between">
-              <div><p className="text-sm text-muted-foreground">Total Orders</p><p className="text-xl font-semibold tracking-[-0.02em]">{stats.totalOrders}</p></div>
-              <ShoppingCart className="h-8 w-8 text-muted-foreground" />
-            </div>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent className="pt-4">
-            <div className="flex items-center justify-between">
-              <div><p className="text-sm text-muted-foreground">Pending Orders</p><p className="text-xl font-semibold tracking-[-0.02em] text-amber-600">{stats.pendingOrders}</p></div>
-              <ShoppingCart className="h-8 w-8 text-amber-500" />
-            </div>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent className="pt-4">
-            <div className="flex items-center justify-between">
-              <div><p className="text-sm text-muted-foreground">Unpaid Invoices</p><p className="text-xl font-semibold tracking-[-0.02em] text-red-600">{stats.unpaidInvoices}</p></div>
-              <FileText className="h-8 w-8 text-red-500" />
-            </div>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent className="pt-4">
-            <div className="flex items-center justify-between">
-              <div><p className="text-sm text-muted-foreground">Customers</p><p className="text-xl font-semibold tracking-[-0.02em]">{stats.totalCustomers}</p></div>
-              <Users className="h-8 w-8 text-muted-foreground" />
-            </div>
-          </CardContent>
-        </Card>
       </div>
 
       {/* Unified Orders & Sales Table */}


### PR DESCRIPTION
## Summary
Refactored dashboard and hub page headers across the application to use a unified, compact single-row layout pattern. This change replaces multi-line headers with descriptive subtitles and separate stat cards with an inline header bar that displays key metrics directly in the header row.

## Key Changes

- **Consolidated header layouts**: Replaced traditional two-line headers (title + subtitle) with single-row headers containing the title and key stats inline
- **Removed stat card grids**: Eliminated dedicated stat card sections (previously 4-6 card grids) from:
  - EDI Dashboard
  - Grant & Bid Submitter
  - Sales Hub (Orders & Sales)
  - Data Rooms
  - Logistics Hub
  - CRM Hub
  - Recruiting
  
- **Inline metrics display**: Moved key statistics into the header as compact inline elements separated by vertical dividers:
  - Format: `Label` **Value** with color coding (green for positive, red for alerts, etc.)
  - Examples: "Partners **5**", "Active **4**", "Revenue **$50,000**"

- **Reduced vertical spacing**: Changed `space-y-6` to `space-y-2` throughout to accommodate the more compact header design

- **Button sizing**: Updated action buttons to use `size="sm"` for consistency with the more compact header aesthetic

- **Tab layout improvements**: Reorganized tab-based pages (Operations Hub, Investors, Finance, Legal, Marketing & Content) to place title and tabs in a single flex row

- **Simplified page structure**: Removed unnecessary wrapper divs and consolidated header sections across:
  - Projects & Tasks
  - People (Employees)
  - Vendors
  - Messaging
  - SOPs
  - Recipes

## Implementation Details

- Header rows use `flex items-center justify-between gap-4 flex-wrap` for responsive behavior
- Stats are displayed as `<div>` elements with `text-muted-foreground` labels and `font-bold` values
- Vertical dividers use `h-4 w-px bg-border` elements for visual separation
- Color coding applied to values: green-600 for positive metrics, red-600 for errors/alerts, amber-600 for warnings
- All changes maintain existing functionality while improving visual hierarchy and reducing cognitive load

https://claude.ai/code/session_01194hx6U1jVTEqSeChvA12w

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates all dashboard and hub headers into a compact single-row layout with inline KPIs and actions. This reduces vertical scroll, improves scan-ability, and standardizes headers across modules.

- **Refactors**
  - Replaced two-line headers and separate KPI/stat cards with a single flex row: title + inline metrics + actions.
  - Moved metrics inline as small label–value chips with divider bars and color cues; removed KPI/stat card grids.
  - Tightened spacing to `space-y-2` and set header/action buttons to `size="sm"`.
  - Combined page titles and tabs into one row on tabbed screens; simplified wrapper markup.
  - Applied across all modules (CRM, Sales, Finance, EDI, Operations, Legal, Marketing, HR, Logistics, Projects, Data Rooms, SOPs, Vendors, Grants & Bids, Fundraising, Messaging, Meetings, Dashboard).

- **Migration**
  - No functional/API changes.
  - Update tests/selectors that referenced removed stat cards or old header sizes.
  - Use the new pattern on future pages: `flex items-center justify-between gap-4 flex-wrap` with text-xs label–value chips separated by `div` vertical dividers.

<sup>Written for commit d7a9dfe5e45ce6a755e6f8d43379a6ee7a55284d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

