### PR TITLE
Adjust sidebar defaults: reduce width and open by default

### DIFF
--- a/client/src/components/DashboardLayout.tsx
+++ b/client/src/components/DashboardLayout.tsx
@@ -157,9 +157,9 @@ export function getMenuGroups(role: string = "user") {
   return groups;
 }
 
-const SIDEBAR_WIDTH_KEY = "sidebar-width";
-const DEFAULT_WIDTH = 260;
-const MIN_WIDTH = 200;
+const SIDEBAR_WIDTH_KEY = "sidebar-width-v2";
+const DEFAULT_WIDTH = 180;
+const MIN_WIDTH = 160;
 const MAX_WIDTH = 400;
 
 const roleColors: Record<string, string> = {
@@ -197,7 +197,7 @@ export default function DashboardLayout({
 
   return (
     <SidebarProvider
-      defaultOpen={false}
+      defaultOpen={true}
       style={
         {
           "--sidebar-width": `${sidebarWidth}px`,


### PR DESCRIPTION
## Summary
Updated the sidebar configuration in DashboardLayout to provide a more compact default experience with the sidebar open by default.

## Key Changes
- Changed sidebar width storage key from `"sidebar-width"` to `"sidebar-width-v2"` to reset user preferences to new defaults
- Reduced default sidebar width from 260px to 180px for a more compact layout
- Reduced minimum sidebar width from 200px to 160px to allow for narrower configurations
- Changed `defaultOpen` from `false` to `true` so the sidebar is visible on initial load

## Implementation Details
The storage key version bump (`sidebar-width-v2`) ensures that existing user sidebar width preferences won't carry over, allowing all users to experience the new narrower default width. The sidebar will now be expanded by default when users first access the dashboard, improving discoverability of navigation options.

https://claude.ai/code/session_01R7hgPDDFFfo8UDv1YnJdub