### PR TITLE
fix(email): stop marking Gmail messages as read on archive

### DIFF
--- a/server/routers.ts
+++ b/server/routers.ts
@@ -12256,33 +12256,12 @@ Ask if they received the original request and if they can provide a quote.`;
         return db.getEmailScanningStats();
       }),
 
-    // Archive email
+    // Archive email (local-only — does not touch Gmail/IMAP read state)
     archiveEmail: protectedProcedure
       .input(z.object({ id: z.number() }))
       .mutation(async ({ input, ctx }) => {
         if (!['admin', 'ops'].includes(ctx.user.role)) {
           throw new TRPCError({ code: 'FORBIDDEN' });
-        }
-        const email = await db.getInboundEmailById(input.id);
-        // Archive in Gmail — mark as read and move out of inbox
-        if (email?.messageId) {
-          try {
-            const { getImapConfig } = await import("./_core/emailInboxScanner");
-            const { ImapFlow } = await import("imapflow");
-            const config = getImapConfig();
-            if (config) {
-              const client = new ImapFlow({ host: config.host, port: config.port, secure: config.secure, auth: config.auth, logger: false });
-              await client.connect();
-              await client.mailboxOpen("INBOX");
-              const uids = await client.search({ header: { "message-id": email.messageId } }, { uid: true });
-              if (uids && uids.length > 0) {
-                await client.messageFlagsAdd(uids, ["\\Seen"], { uid: true });
-              }
-              await client.logout();
-            }
-          } catch (e) {
-            console.warn(`[Email] Failed to archive in Gmail:`, e instanceof Error ? e.message : e);
-          }
         }
         await db.updateInboundEmailStatus(input.id, "archived");
         return { success: true };


### PR DESCRIPTION
## Summary

Reported issue: Gmail messages were showing up as read before the user opened them in Gmail.

Root cause: `emailScanning.archiveEmail` (`server/routers.ts`) connected to the user's inbox over IMAP and ran `messageFlagsAdd(["\Seen"])` on every archived message. Archiving in our app silently flipped the message to read on Gmail's server, so by the time the user checked Gmail it already looked read. The inline comment ("mark as read and move out of inbox") was also misleading — the code never moved the message anywhere, only set `\Seen`.

What I checked but ruled out:
- The IMAP polling worker (`server/_core/index.ts:1278`) and all `scanInbox` callers explicitly pass `markAsSeen: false`, so the periodic sync isn't the culprit.
- imapflow's `fetch()` / `download()` always emit `BODY.PEEK[]` for body and source fetches (verified in `imapflow@1.2.16` `lib/commands/fetch.js` line 90 and the `setBodyPeek` helper), so reading bodies during a scan does not set `\Seen` on the server.
- The Gmail OAuth client (`server/_core/gmail.ts`) only requests `gmail.readonly` / `gmail.send` / `gmail.compose` scopes, so it cannot modify message labels.

Fix: drop the IMAP block from `archiveEmail` so archiving is a purely local DB status change. `deleteEmail` is unchanged — when the user explicitly deletes, we still expunge from Gmail.

## Test plan

- [ ] Archive an email from the inbox UI → it disappears from our app's inbox view
- [ ] Same message in Gmail remains **unread** (bold) until opened in Gmail
- [ ] Delete an email from the inbox UI → still removed from Gmail (regression check on `deleteEmail`)
- [ ] Periodic IMAP polling continues to ingest new emails without flipping their read state

https://claude.ai/code/session_01WcyYYuBtVcFetjicJNTDDs

---
_Generated by [Claude Code](https://claude.ai/code/session_01WcyYYuBtVcFetjicJNTDDs)_