### PR TITLE
Fix build-breaking syntax corruption in RdTaxCredit and ShopifySettings

### DIFF
--- a/client/src/pages/finance/RdTaxCredit.tsx
+++ b/client/src/pages/finance/RdTaxCredit.tsx
@@ -817,86 +817,80 @@ type QBImportCategory = "wages" | "supplies" | "contract_research" | "cloud_comp
 
 function ImportFromQBButton({ studyId, projects, onRefresh }: {
   studyId: number;
-  projects: Array<{ id?: number | null; projectName?: string | null }>;
+  projects: RdProjectRow[];
   onRefresh: () => void;
 }) {
   const [open, setOpen] = useState(false);
-      min={0}
-      max={100}
-      value={draft}
-      onChange={(e) => setDraft(e.target.value)}
-      onBlur={commit}
-      onKeyDown={(e) => {
-        if (e.key === "Enter") commit();
-        if (e.key === "Escape") setEditing(false);
-      }}
-      className="w-16 rounded border bg-background px-1 text-right text-sm"
-    />
-  );
-}
+  const [projectId, setProjectId] = useState("");
+  const [startDate, setStartDate] = useState(() => {
+    const d = new Date(); d.setMonth(0, 1); return d.toISOString().slice(0, 10);
+  });
+  const [endDate, setEndDate] = useState(() => new Date().toISOString().slice(0, 10));
+  const [category, setCategory] = useState<QBImportCategory>("wages");
 
-// ============================================
-// IMPORT FROM QB BUTTON (Issue #270)
-// ============================================
-type QBImportCategory = "wages" | "supplies" | "contract_research" | "cloud_computing";
+  const importMutation = trpc.rdTaxCredit.importFromQuickBooks.useMutation({
+    onSuccess: (data: any) => {
+      toast.success(`Imported ${data.imported ?? 0} expense(s) from QuickBooks`);
+      setOpen(false);
+      onRefresh();
+    },
+    onError: (e: any) => toast.error(e.message),
+  });
 
-function ImportFromQBButton({ studyId, projects, onRefresh }: {
-  studyId: number;
-  projects: Array<{ id?: number | null; projectName?: string | null }>;
-  onRefresh: () => void;
-}) {
-  const [open, setOpen] = useState(false);
-      min={0}
-      max={100}
-      value={draft}
-      onChange={(e) => setDraft(e.target.value)}
-      onBlur={commit}
-      onKeyDown={(e) => {
-        if (e.key === "Enter") commit();
-        if (e.key === "Escape") setEditing(false);
-      }}
-      className="w-16 rounded border bg-background px-1 text-right text-sm"
-    />
-  );
-}
-
-// ============================================
-// IMPORT FROM QB BUTTON (Issue #270)
-// ============================================
-type QBImportCategory = "wages" | "supplies" | "contract_research" | "cloud_computing";
-
-function ImportFromQBButton({ studyId, projects, onRefresh }: {
-  studyId: number;
-  projects: Array<{ id?: number | null; projectName?: string | null }>;
-  onRefresh: () => void;
-}) {
-  const [open, setOpen] = useState(false);
-      min={0}
-      max={100}
-      value={draft}
-      onChange={(e) => setDraft(e.target.value)}
-      onBlur={commit}
-      onKeyDown={(e) => {
-        if (e.key === "Enter") commit();
-        if (e.key === "Escape") setEditing(false);
-      }}
-      className="w-16 rounded border bg-background px-1 text-right text-sm"
-    />
-  );
-}
-
-// ============================================
-// IMPORT FROM QB BUTTON (Issue #270)
+  return (
+    <>
+      <Button size="sm" variant="outline" onClick={() => setOpen(true)}>
+        <Download className="h-4 w-4 mr-1" /> Import from QuickBooks
+      </Button>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>Import from QuickBooks</DialogTitle>
+            <DialogDescription>
+              Pull posted QuickBooks transactions matching the date range and category.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div>
+              <Label>Project</Label>
+              <Select value={projectId} onValueChange={setProjectId}>
+                <SelectTrigger><SelectValue placeholder="Select project" /></SelectTrigger>
+                <SelectContent>
+                  {projects.map((p) => (
+                    <SelectItem key={p.id} value={String(p.id)}>{p.projectName}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
             <div className="grid grid-cols-2 gap-4">
               <div><Label>Start Date</Label><Input type="date" value={startDate} onChange={e => setStartDate(e.target.value)} /></div>
               <div><Label>End Date</Label><Input type="date" value={endDate} onChange={e => setEndDate(e.target.value)} /></div>
+            </div>
+            <div>
+              <Label>Category</Label>
+              <Select value={category} onValueChange={(v) => setCategory(v as QBImportCategory)}>
+                <SelectTrigger><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="wages">Employee Wages</SelectItem>
+                  <SelectItem value="supplies">Supplies</SelectItem>
+                  <SelectItem value="contract_research">Contract Research (65%)</SelectItem>
+                  <SelectItem value="cloud_computing">Cloud Computing</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setOpen(false)}>Cancel</Button>
+            <Button
+              onClick={() => importMutation.mutate({ studyId, projectId: parseInt(projectId), startDate, endDate, category })}
+              disabled={!projectId || importMutation.isPending}
+            >
+              {importMutation.isPending && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+              Import Expenses
+            </Button>
+          </DialogFooter>
+        </DialogContent>
       </Dialog>
     </>
-  );
-}
-  );
-}
-  );
-}
   );
 }

--- a/client/src/pages/settings/ShopifySettings.tsx
+++ b/client/src/pages/settings/ShopifySettings.tsx
@@ -422,13 +422,16 @@ function AddLocationMappingButton({ storeId }: { storeId: number }) {
               onClick={() => createMapping.mutate({
                 storeId,
                 shopifyLocationId,
-                                warehouseId: parseInt(warehouseId),
+                warehouseId: parseInt(warehouseId),
               })}
               disabled={!shopifyLocationId || !warehouseId || createMapping.isPending}
             >
+              {createMapping.isPending && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
               Create Mapping
             </Button>
           </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </>
   );
 }

--- a/scripts/strict-ratchet.mjs
+++ b/scripts/strict-ratchet.mjs
@@ -45,9 +45,17 @@ function runStrict() {
     if (output.trim()) console.error(output.trim());
     process.exit(2);
   }
-  // tsc exits 0 with no errors, 1 with type errors.
-  // Other exit codes (e.g. 2 for config/options errors) are fatal.
-  if (r.status !== 0 && r.status !== 1) {
+  // tsc's diagnostic exit codes (all mean "ran to completion, diagnostics may
+  // be present" — we always parse `output` for the per-file counts):
+  //   0 = Success (no errors)
+  //   1 = DiagnosticsPresent_OutputsSkipped   (errors, nothing emitted)
+  //   2 = DiagnosticsPresent_OutputsGenerated (errors, but an output was still
+  //       written — happens here because the base tsconfig sets
+  //       `incremental: true`, so a cold run with no cached `.tsbuildinfo`
+  //       writes one even under `--noEmit`. A warm run skips the write and
+  //       exits 1. CI always runs cold, so it always sees 2.)
+  // Anything else (3/4 project-reference errors, etc.) is a real tooling fault.
+  if (r.status !== 0 && r.status !== 1 && r.status !== 2) {
     console.error(
       `Strict typecheck failed with exit code ${r.status}. This usually indicates a tooling/config issue (e.g. pnpm not available or invalid TypeScript config).`,
     );


### PR DESCRIPTION
## Problem

`pnpm check` was failing — the project did not typecheck. Two files were left in a non-compiling state by recent commits (`a4bc470` and the squash merge `7f790f5`):

- **`client/src/pages/finance/RdTaxCredit.tsx`** — `ImportFromQBButton` was triplicated, each copy with a garbage body (stray `<input>` attributes from `InlineRdPercent`, no real component body), leaving dangling `);}` at EOF. ~30 TS syntax errors.
- **`client/src/pages/settings/ShopifySettings.tsx`** — the "Add Location Mapping" dialog was missing its closing `</DialogContent></Dialog>` tags (and the pending spinner), producing "JSX fragment / Dialog has no corresponding closing tag" errors.

## Fix

- Restored a single, complete `ImportFromQBButton`, typed against `RdProjectRow[]` to match its call site in `ExpensesTab`. `InlineRdPercent` was already intact and is untouched.
- Restored the missing closing tags and the `createMapping.isPending` spinner in `ShopifySettings`. The `createMapping.mutate` params (`storeId`, `shopifyLocationId`, `warehouseId`) already match the server schema in `server/routers.ts` (`locationName` is not accepted server-side, so it stays dropped).

## Strict Ratchet CI fix (`scripts/strict-ratchet.mjs`)

The Strict Ratchet job was failing on this PR — but as a **latent, pre-existing bug unrelated to the diff**. The base tsconfig sets `incremental: true` with a `tsBuildInfoFile`, so a *cold* `tsc --noEmit` run (no cached `.tsbuildinfo`) writes the buildinfo output and exits `2` (`DiagnosticsPresent_OutputsGenerated`) instead of `1` (`OutputsSkipped`). CI always runs cold, so `runStrict()` — which only accepted exit codes 0/1 — treated `2` as a fatal tooling error and bailed before ever comparing to the baseline, failing every PR.

Fix: treat exit code `2` the same as `0/1` (tsc ran to completion; parse its diagnostics). Codes `3/4` (project-reference errors) and `null` (killed) remain fatal. Verified a cold run now reports `Strict ratchet OK` (141 errors, baseline 142) and exits 0.

## Verification

- `pnpm check` — clean (0 errors)
- `pnpm strict:check` (cold + warm) — OK, 141 errors under the 142 baseline
- `pnpm test` — **868 passed**, including the 35 `DashboardLayout` sidebar-contract tests

https://claude.ai/code/session_01QV5EYi6eF7Sj7SQoPjypdY