### PR TITLE
Add prompt caching support to the Anthropic LLM provider

### DIFF
--- a/server/_core/llm.test.ts
+++ b/server/_core/llm.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Provide a fake API key/model so invokeLLM doesn't throw and the model is stable.
+vi.mock('./env', () => ({
+  ENV: {
+    llmApiKey: 'test-key',
+    llmApiUrl: '',
+    llmModel: 'claude-sonnet-4-20250514',
+  },
+}));
+
+import { invokeLLM } from './llm';
+
+type CapturedRequest = { url: string; body: any };
+
+function mockFetch(usage?: Record<string, number>): {
+  fetchMock: ReturnType<typeof vi.fn>;
+  captured: CapturedRequest[];
+} {
+  const captured: CapturedRequest[] = [];
+  const fetchMock = vi.fn(async (url: string, init: RequestInit) => {
+    captured.push({ url, body: JSON.parse(init.body as string) });
+    return {
+      ok: true,
+      json: async () => ({
+        id: 'msg_1',
+        model: 'claude-sonnet-4-20250514',
+        content: [{ type: 'text', text: 'hi' }],
+        stop_reason: 'end_turn',
+        usage: { input_tokens: 10, output_tokens: 5, ...usage },
+      }),
+    } as any;
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  return { fetchMock, captured };
+}
+
+describe('invokeLLM prompt caching', () => {
+  beforeEach(() => vi.restoreAllMocks());
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('does not add cache_control by default', async () => {
+    const { captured } = mockFetch();
+    await invokeLLM({
+      messages: [
+        { role: 'system', content: 'You are a helpful ERP assistant.' },
+        { role: 'user', content: 'Hello' },
+      ],
+    });
+    expect(typeof captured[0].body.system).toBe('string');
+    expect(JSON.stringify(captured[0].body)).not.toContain('cache_control');
+  });
+
+  it('caches the system prompt prefix when cache: true', async () => {
+    const { captured } = mockFetch();
+    await invokeLLM({
+      cache: true,
+      messages: [
+        { role: 'system', content: 'You are a helpful ERP assistant.' },
+        { role: 'user', content: 'Hello' },
+      ],
+    });
+    const system = captured[0].body.system;
+    expect(Array.isArray(system)).toBe(true);
+    expect(system[0].cache_control).toEqual({ type: 'ephemeral' });
+    expect(system[0].text).toBe('You are a helpful ERP assistant.');
+  });
+
+  it('caches the system prompt including an appended JSON-schema instruction', async () => {
+    const { captured } = mockFetch();
+    await invokeLLM({
+      cache: true,
+      messages: [
+        { role: 'system', content: 'Base prompt.' },
+        { role: 'user', content: 'Extract' },
+      ],
+      outputSchema: {
+        name: 'thing',
+        schema: { type: 'object', properties: { a: { type: 'string' } } },
+      },
+    });
+    const system = captured[0].body.system;
+    expect(Array.isArray(system)).toBe(true);
+    // Breakpoint must cover the whole assembled system text, schema included.
+    expect(system[0].text).toContain('Base prompt.');
+    expect(system[0].text).toContain('valid JSON matching this schema');
+    expect(system[0].cache_control).toEqual({ type: 'ephemeral' });
+  });
+
+  it('marks the last tool with the cache breakpoint', async () => {
+    const { captured } = mockFetch();
+    await invokeLLM({
+      cache: true,
+      messages: [{ role: 'user', content: 'Hello' }],
+      tools: [
+        { type: 'function', function: { name: 'a', description: 'A' } },
+        { type: 'function', function: { name: 'b', description: 'B' } },
+      ],
+    });
+    const tools = captured[0].body.tools;
+    expect(tools[0].cache_control).toBeUndefined();
+    expect(tools[1].cache_control).toEqual({ type: 'ephemeral' });
+  });
+
+  it('supports a 1-hour TTL', async () => {
+    const { captured } = mockFetch();
+    await invokeLLM({
+      cache: { ttl: '1h' },
+      messages: [
+        { role: 'system', content: 'Long-lived prompt.' },
+        { role: 'user', content: 'Hi' },
+      ],
+    });
+    expect(captured[0].body.system[0].cache_control).toEqual({
+      type: 'ephemeral',
+      ttl: '1h',
+    });
+  });
+
+  it('can cache only tools, leaving the system prompt as a plain string', async () => {
+    const { captured } = mockFetch();
+    await invokeLLM({
+      cache: { system: false, tools: true },
+      messages: [
+        { role: 'system', content: 'Prompt.' },
+        { role: 'user', content: 'Hi' },
+      ],
+      tools: [{ type: 'function', function: { name: 'a' } }],
+    });
+    expect(typeof captured[0].body.system).toBe('string');
+    expect(captured[0].body.tools[0].cache_control).toEqual({ type: 'ephemeral' });
+  });
+
+  it('reports cache usage and a full prompt-token total', async () => {
+    mockFetch({
+      input_tokens: 10,
+      cache_creation_input_tokens: 100,
+      cache_read_input_tokens: 900,
+    });
+    const result = await invokeLLM({
+      cache: true,
+      messages: [
+        { role: 'system', content: 'Prompt.' },
+        { role: 'user', content: 'Hi' },
+      ],
+    });
+    // prompt_tokens = uncached + cache writes + cache reads = 10 + 100 + 900.
+    expect(result.usage?.prompt_tokens).toBe(1010);
+    expect(result.usage?.cache_creation_input_tokens).toBe(100);
+    expect(result.usage?.cache_read_input_tokens).toBe(900);
+    expect(result.usage?.total_tokens).toBe(1015);
+  });
+});

--- a/server/_core/llm.ts
+++ b/server/_core/llm.ts
@@ -61,6 +61,33 @@ export type ToolChoice =
   | ToolChoiceByName
   | ToolChoiceExplicit;
 
+// Prompt caching (Anthropic ephemeral cache).
+//
+// Cache writes happen only at a cache breakpoint, and the cache is a prefix
+// match — render order is `tools` → `system` → `messages`. The stable,
+// reusable prefix for this codebase is the system prompt (and tool
+// definitions); the incoming user message varies per request. So we place the
+// breakpoint at the end of the system prompt and on the last tool, NOT on the
+// trailing message. Marking the volatile final message (what top-level
+// "automatic" caching would do) writes a fresh entry every request and never
+// reads — see the prompt-caching docs' "common mistake".
+//
+// Caching is opt-in per call: pass `cache: true` (or a CacheOptions object).
+// The 5-minute cache refreshes for free on each hit; use `ttl: "1h"` for
+// prefixes reused less often than every 5 minutes (2x the write cost).
+export type CacheTtl = "5m" | "1h";
+
+export type CacheOptions = {
+    // Cache the system prompt prefix (caches preceding tools too). Default true.
+    system?: boolean;
+    // Cache the tool definitions block. Default true when tools are present.
+    tools?: boolean;
+    // Cache lifetime. Default "5m".
+    ttl?: CacheTtl;
+};
+
+export type CacheControlOption = boolean | CacheOptions;
+
 export type InvokeParams = {
     messages: Message[];
     tools?: Tool[];
@@ -72,6 +99,8 @@ export type InvokeParams = {
     output_schema?: OutputSchema;
     responseFormat?: ResponseFormat;
     response_format?: ResponseFormat;
+    cache?: CacheControlOption;
+    cache_control?: CacheControlOption;
 };
 
 export type ToolCall = {
@@ -100,6 +129,12 @@ export type InvokeResult = {
       prompt_tokens: number;
       completion_tokens: number;
       total_tokens: number;
+      // Anthropic prompt-caching breakdown (0 when caching is not in effect).
+      // `prompt_tokens` above is the full input count
+      // (uncached + cache reads + cache writes), so existing cost math stays
+      // correct; these fields let callers track cache hit rates.
+      cache_creation_input_tokens?: number;
+      cache_read_input_tokens?: number;
     };
 };
 
@@ -216,8 +251,29 @@ type AnthropicResponse = {
     usage: {
       input_tokens: number;
       output_tokens: number;
+      cache_creation_input_tokens?: number;
+      cache_read_input_tokens?: number;
     };
 };
+
+type CacheControl = { type: "ephemeral"; ttl?: "1h" };
+
+// Resolve the user-supplied cache option into a concrete config, or null when
+// caching is disabled.
+function resolveCacheOptions(
+    option: CacheControlOption | undefined,
+  ): { system: boolean; tools: boolean; control: CacheControl } | null {
+    if (!option) return null;
+    const opts: CacheOptions = option === true ? {} : option;
+    const ttl = opts.ttl ?? "5m";
+    const control: CacheControl =
+          ttl === "1h" ? { type: "ephemeral", ttl: "1h" } : { type: "ephemeral" };
+    return {
+          system: opts.system ?? true,
+          tools: opts.tools ?? true,
+          control,
+    };
+}
 
 function convertContentToAnthropic(content: MessageContent | MessageContent[]): unknown {
     const parts = ensureArray(content);
@@ -305,12 +361,21 @@ function convertMessagesToAnthropic(messages: Message[]): { system: string | und
   return { system, messages: anthropicMessages };
 }
 
-function convertToolsToAnthropic(tools: Tool[]): unknown[] {
-    return tools.map(t => ({
+function convertToolsToAnthropic(
+    tools: Tool[],
+    cacheControl?: CacheControl,
+  ): unknown[] {
+    const converted = tools.map(t => ({
           name: t.function.name,
           description: t.function.description ?? "",
           input_schema: t.function.parameters ?? { type: "object", properties: {} },
     }));
+    // A single breakpoint on the last tool caches every preceding tool too.
+    if (cacheControl && converted.length > 0) {
+          (converted[converted.length - 1] as Record<string, unknown>).cache_control =
+                  cacheControl;
+    }
+    return converted;
 }
 
 function convertAnthropicToolChoice(
@@ -376,13 +441,25 @@ function convertAnthropicResponse(anthropicResp: AnthropicResponse): InvokeResul
                       ? "tool_calls"
                               : anthropicResp.stop_reason,
         }],
-        usage: {
-                prompt_tokens: anthropicResp.usage.input_tokens,
-                completion_tokens: anthropicResp.usage.output_tokens,
-                total_tokens:
-                          anthropicResp.usage.input_tokens + anthropicResp.usage.output_tokens,
-        },
+        usage: buildUsage(anthropicResp.usage),
   };
+}
+
+function buildUsage(
+    usage: AnthropicResponse["usage"],
+  ): NonNullable<InvokeResult["usage"]> {
+    const cacheCreation = usage.cache_creation_input_tokens ?? 0;
+    const cacheRead = usage.cache_read_input_tokens ?? 0;
+    // `input_tokens` only counts tokens after the last cache breakpoint, so the
+    // full prompt size is the sum of uncached + cache writes + cache reads.
+    const promptTokens = usage.input_tokens + cacheCreation + cacheRead;
+    return {
+          prompt_tokens: promptTokens,
+          completion_tokens: usage.output_tokens,
+          total_tokens: promptTokens + usage.output_tokens,
+          ...(cacheCreation > 0 ? { cache_creation_input_tokens: cacheCreation } : {}),
+          ...(cacheRead > 0 ? { cache_read_input_tokens: cacheRead } : {}),
+    };
 }
 
 // ============================================
@@ -403,7 +480,11 @@ export async function invokeLLM(params: InvokeParams): Promise<InvokeResult> {
         output_schema,
         responseFormat,
         response_format,
+        cache,
+        cache_control,
   } = params;
+
+  const cacheConfig = resolveCacheOptions(cache ?? cache_control);
 
   const converted = convertMessagesToAnthropic(messages);
 
@@ -418,7 +499,10 @@ export async function invokeLLM(params: InvokeParams): Promise<InvokeResult> {
   }
 
   if (tools && tools.length > 0) {
-        payload.tools = convertToolsToAnthropic(tools);
+        payload.tools = convertToolsToAnthropic(
+                tools,
+                cacheConfig?.tools ? cacheConfig.control : undefined,
+        );
   }
 
   const anthropicToolChoice = convertAnthropicToolChoice(toolChoice || tool_choice, tools);
@@ -441,6 +525,19 @@ export async function invokeLLM(params: InvokeParams): Promise<InvokeResult> {
   } else if (normalizedResponseFormat && normalizedResponseFormat.type === "json_object") {
         const jsonInstruction = `\n\nYou MUST respond with valid JSON. Respond ONLY with the JSON object, no other text.`;
         payload.system = (converted.system ?? "") + jsonInstruction;
+  }
+
+  // Place the cache breakpoint at the end of the (now fully assembled) system
+  // prompt. Done last so the cached prefix includes any appended JSON-schema
+  // instruction; a breakpoint here also caches the preceding tools block.
+  if (cacheConfig?.system && typeof payload.system === "string" && payload.system.length > 0) {
+        payload.system = [
+                {
+                          type: "text",
+                          text: payload.system,
+                          cache_control: cacheConfig.control,
+                },
+        ];
   }
 
   const response = await fetch(resolveAnthropicUrl(), {


### PR DESCRIPTION
## What

Adds opt-in [Anthropic ephemeral prompt caching](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching) to the LLM module (`server/_core/llm.ts`).

Callers enable it per request:

```ts
invokeLLM({ cache: true, messages, tools });          // 5-minute TTL (default)
invokeLLM({ cache: { ttl: "1h" }, messages });        // 1-hour TTL
invokeLLM({ cache: { system: false, tools: true }, messages, tools });
```

## Why this placement

Prompt caching is a **prefix match**, and the cache is written only at the `cache_control` breakpoint. For this codebase the stable, reusable prefix is the **system prompt** (and tool definitions); the incoming user message varies every request. So the breakpoint goes at the end of the system prompt and on the last tool — **not** on the trailing message.

Putting the breakpoint on the volatile final message (what top-level "automatic" caching does) would write a fresh cache entry on every request and never read one — the documented common mistake. This implementation avoids that.

## Details

- A single breakpoint on the last system block caches the preceding `tools` block too (render order is `tools` → `system` → `messages`).
- The system breakpoint is applied **after** the JSON-schema/JSON-object instruction is appended, so the cached prefix covers the full assembled system text.
- Supports 5-minute (default) and 1-hour TTLs via `ttl`.
- `system` / `tools` can be toggled independently.
- Off by default — no behavior change for existing callers.
- Surfaces `cache_creation_input_tokens` / `cache_read_input_tokens` in `usage`, and reports `prompt_tokens` as the full input count (uncached + cache writes + cache reads) so cost math stays correct.

## Tests

New `server/_core/llm.test.ts` (7 tests) covers: no caching by default, system-prefix caching, caching the system prompt including the appended JSON-schema instruction, last-tool breakpoint placement, 1-hour TTL, tools-only caching, and the usage/token-total reporting. Full suite green (875 tests).

Note: the repo currently has pre-existing typecheck errors in unrelated client files (`RdTaxCredit.tsx`, `ShopifySettings.tsx`); this change adds none.

https://claude.ai/code/session_012Fe2ezKr8XEPV25FWYUFHx

---
_Generated by [Claude Code](https://claude.ai/code/session_012Fe2ezKr8XEPV25FWYUFHx)_