### PR TITLE
Add file name search to Drive import file lists

### DIFF
--- a/client/src/lib/importFields.test.ts
+++ b/client/src/lib/importFields.test.ts
@@ -3,6 +3,8 @@ import {
   suggestFieldForHeader,
   buildDefaultMapping,
   missingRequiredFields,
+  coerceImportValue,
+  buildImportRecord,
   IMPORT_SKIP,
 } from "@shared/importFields";
 
@@ -53,5 +55,54 @@ describe("missingRequiredFields", () => {
   it("returns nothing once all required fields are mapped", () => {
     const mapping = { A: "firstName", B: "lastName" };
     expect(missingRequiredFields("employees", mapping)).toHaveLength(0);
+  });
+});
+
+
+describe("coerceImportValue", () => {
+  const def = (type: any, enumValues?: string[]) => ({ key: "f", label: "F", type, enumValues });
+
+  it("parses decimals, stripping currency/commas", () => {
+    expect(coerceImportValue("$1,200.50", def("decimal"))).toEqual({ value: "1200.50" });
+    expect(coerceImportValue("not money", def("decimal")).error).toBeTruthy();
+  });
+
+  it("parses ints and dates", () => {
+    expect(coerceImportValue("45", def("int"))).toEqual({ value: 45 });
+    expect(coerceImportValue("abc", def("int")).error).toBeTruthy();
+    const d = coerceImportValue("2025-01-15", def("date")).value as Date;
+    expect(d instanceof Date && d.getUTCFullYear()).toBe(2025);
+    expect(coerceImportValue("nope", def("date")).error).toBeTruthy();
+  });
+
+  it("matches enums case-insensitively and rejects unknowns", () => {
+    expect(coerceImportValue("Business", def("enum", ["individual", "business"]))).toEqual({ value: "business" });
+    expect(coerceImportValue("vip", def("enum", ["individual", "business"])).error).toBeTruthy();
+  });
+
+  it("treats blank as undefined (not an error)", () => {
+    expect(coerceImportValue("  ", def("string"))).toEqual({ value: undefined });
+  });
+});
+
+describe("buildImportRecord", () => {
+  it("coerces mapped columns into a typed record", () => {
+    const { record, errors } = buildImportRecord(
+      { Name: "Acme", Kind: "Business", Credit: "$50,000", Terms: "45" },
+      { Name: "name", Kind: "type", Credit: "creditLimit", Terms: "paymentTerms" },
+      "customers",
+    );
+    expect(errors).toHaveLength(0);
+    expect(record).toEqual({ name: "Acme", type: "business", creditLimit: "50000", paymentTerms: 45 });
+  });
+
+  it("reports an error for an invalid enum value", () => {
+    const { errors } = buildImportRecord({ Name: "Acme", Kind: "vip" }, { Name: "name", Kind: "type" }, "customers");
+    expect(errors.some((e) => /Type/.test(e))).toBe(true);
+  });
+
+  it("flags a missing required field", () => {
+    const { errors } = buildImportRecord({ Email: "a@b.com" }, { Email: "email" }, "customers");
+    expect(errors.some((e) => /Name/.test(e))).toBe(true);
   });
 });

--- a/client/src/lib/importFields.test.ts
+++ b/client/src/lib/importFields.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import {
+  suggestFieldForHeader,
+  buildDefaultMapping,
+  missingRequiredFields,
+  IMPORT_SKIP,
+} from "@shared/importFields";
+
+describe("suggestFieldForHeader", () => {
+  it("maps common header variants to the canonical field", () => {
+    expect(suggestFieldForHeader("Customer Name", "customers")).toBe("name");
+    expect(suggestFieldForHeader("name", "customers")).toBe("name");
+    expect(suggestFieldForHeader("Email Address", "customers")).toBe("email");
+    expect(suggestFieldForHeader("Zip Code", "customers")).toBe("postalCode");
+    expect(suggestFieldForHeader("Surname", "employees")).toBe("lastName");
+    expect(suggestFieldForHeader("First Name", "employees")).toBe("firstName");
+    expect(suggestFieldForHeader("Sell Price", "products")).toBe("unitPrice");
+  });
+
+  it("returns the skip sentinel when nothing matches", () => {
+    expect(suggestFieldForHeader("Random Column 42", "customers")).toBe(IMPORT_SKIP);
+    expect(suggestFieldForHeader("", "customers")).toBe(IMPORT_SKIP);
+  });
+});
+
+describe("buildDefaultMapping", () => {
+  it("auto-maps a realistic header set without reusing a field", () => {
+    const mapping = buildDefaultMapping(
+      ["Customer Name", "E-mail", "Phone Number", "Mystery"],
+      "customers",
+    );
+    expect(mapping).toEqual({
+      "Customer Name": "name",
+      "E-mail": "email",
+      "Phone Number": "phone",
+      Mystery: IMPORT_SKIP,
+    });
+  });
+
+  it("does not assign the same field to two headers", () => {
+    const mapping = buildDefaultMapping(["Name", "Company"], "customers");
+    const assigned = Object.values(mapping).filter((v) => v !== IMPORT_SKIP);
+    expect(new Set(assigned).size).toBe(assigned.length);
+  });
+});
+
+describe("missingRequiredFields", () => {
+  it("flags required fields that are not mapped", () => {
+    const missing = missingRequiredFields("employees", { "First Name": "firstName" });
+    expect(missing.map((f) => f.key)).toEqual(["lastName"]);
+  });
+
+  it("returns nothing once all required fields are mapped", () => {
+    const mapping = { A: "firstName", B: "lastName" };
+    expect(missingRequiredFields("employees", mapping)).toHaveLength(0);
+  });
+});

--- a/client/src/pages/Import.tsx
+++ b/client/src/pages/Import.tsx
@@ -3,6 +3,7 @@ import { trpc } from "@/lib/trpc";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
 import { Separator } from "@/components/ui/separator";
 import {
   FileSpreadsheet,
@@ -18,6 +19,7 @@ import {
   File,
   Download,
   HardDrive,
+  Search,
 } from "lucide-react";
 import React, { useState, useEffect, useCallback } from "react";
 import * as XLSX from "xlsx";
@@ -62,6 +64,7 @@ function DriveFileBrowser({ onSyncAll }: { onSyncAll: () => void }) {
   const { data: spreadsheets, isLoading } = trpc.sheetsImport.listSpreadsheets.useQuery(undefined, { enabled: showBrowser });
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [syncing, setSyncing] = useState(false);
+  const [search, setSearch] = useState("");
 
   const syncSelectedMutation = trpc.sheetsImport.syncGoogleDrive.useMutation({
     onSuccess: (data) => {
@@ -83,23 +86,47 @@ function DriveFileBrowser({ onSyncAll }: { onSyncAll: () => void }) {
   };
 
   const files = (spreadsheets as any)?.spreadsheets || [];
+  const query = search.trim().toLowerCase();
+  const filteredFiles = query
+    ? files.filter((f: any) => (f.name || "").toLowerCase().includes(query))
+    : files;
+  const allFilteredSelected = filteredFiles.length > 0 && filteredFiles.every((f: any) => selectedIds.has(f.id));
 
   return (
     <div className="space-y-3">
       <div className="flex items-center justify-between">
         <h4 className="text-sm font-medium">Google Drive Files</h4>
         <div className="flex gap-2">
-          <Button variant="outline" size="sm" onClick={() => {
-            if (selectedIds.size === files.length) setSelectedIds(new Set());
-            else setSelectedIds(new Set(files.map((f: any) => f.id)));
+          <Button variant="outline" size="sm" disabled={filteredFiles.length === 0} onClick={() => {
+            if (allFilteredSelected) {
+              const next = new Set(selectedIds);
+              filteredFiles.forEach((f: any) => next.delete(f.id));
+              setSelectedIds(next);
+            } else {
+              const next = new Set(selectedIds);
+              filteredFiles.forEach((f: any) => next.add(f.id));
+              setSelectedIds(next);
+            }
           }}>
-            {selectedIds.size === files.length ? "Deselect All" : "Select All"}
+            {allFilteredSelected ? "Deselect All" : "Select All"}
           </Button>
           <Button variant="outline" size="sm" onClick={onSyncAll}>
             <RefreshCw className="h-3 w-3 mr-1" /> Sync All
           </Button>
         </div>
       </div>
+
+      {files.length > 0 && (
+        <div className="relative">
+          <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
+          <Input
+            placeholder="Search files by name..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="pl-8 h-8"
+          />
+        </div>
+      )}
 
       {isLoading ? (
         <div className="flex items-center justify-center py-8">
@@ -109,9 +136,13 @@ function DriveFileBrowser({ onSyncAll }: { onSyncAll: () => void }) {
         <div className="text-center py-6 text-sm text-muted-foreground">
           No spreadsheets found in your Google Drive.
         </div>
+      ) : filteredFiles.length === 0 ? (
+        <div className="text-center py-6 text-sm text-muted-foreground">
+          No files match "{search}".
+        </div>
       ) : (
         <div className="border rounded-lg divide-y max-h-64 overflow-y-auto">
-          {files.map((file: any) => (
+          {filteredFiles.map((file: any) => (
             <label
               key={file.id}
               className="flex items-center gap-3 p-3 hover:bg-muted/50 cursor-pointer transition-colors"
@@ -188,6 +219,7 @@ function formatFileSize(bytes: string | number | undefined) {
 function GoogleDriveFiles() {
   const [activeTab, setActiveTab] = useState(0);
   const [downloadingId, setDownloadingId] = useState<string | null>(null);
+  const [search, setSearch] = useState("");
   const mimeType = DRIVE_TABS[activeTab].mimeType;
 
   const { data, isLoading, refetch } = trpc.sheetsImport.listDriveFiles.useQuery(
@@ -232,6 +264,10 @@ function GoogleDriveFiles() {
   };
 
   const files = data?.files || [];
+  const query = search.trim().toLowerCase();
+  const filteredFiles = query
+    ? files.filter((f: any) => (f.name || "").toLowerCase().includes(query))
+    : files;
 
   return (
     <Card>
@@ -264,6 +300,17 @@ function GoogleDriveFiles() {
           </button>
         </div>
 
+        {/* Search */}
+        <div className="relative mb-3">
+          <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
+          <Input
+            placeholder="Search files by name..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="pl-8 h-8"
+          />
+        </div>
+
         {/* File list */}
         {isLoading ? (
           <div className="flex items-center justify-center py-8">
@@ -271,9 +318,11 @@ function GoogleDriveFiles() {
           </div>
         ) : files.length === 0 ? (
           <div className="text-center py-6 text-sm text-muted-foreground">No files found.</div>
+        ) : filteredFiles.length === 0 ? (
+          <div className="text-center py-6 text-sm text-muted-foreground">No files match "{search}".</div>
         ) : (
           <div className="border rounded-lg divide-y max-h-80 overflow-y-auto">
-            {files.map((file: any) => {
+            {filteredFiles.map((file: any) => {
               const exp = driveExportLabel(file.mimeType);
               const isDownloading = downloadingId === file.id;
               return (

--- a/client/src/pages/Import.tsx
+++ b/client/src/pages/Import.tsx
@@ -25,6 +25,13 @@ import React, { useState, useEffect, useCallback } from "react";
 import * as XLSX from "xlsx";
 import { toast } from "sonner";
 import { useLocation, useSearch } from "wouter";
+import {
+  IMPORT_FIELDS,
+  IMPORT_SKIP,
+  buildDefaultMapping,
+  missingRequiredFields,
+  type ImportModule,
+} from "@shared/importFields";
 
 type SyncResult = {
   sheet: string;
@@ -376,7 +383,7 @@ function CsvImportPanel({ file, onClear, parseXlsx }: {
   onClear: () => void;
   parseXlsx: (f: File) => Promise<{ headers: string[]; rows: Record<string, unknown>[] } | null>;
 }) {
-  const [targetModule, setTargetModule] = useState<string>("");
+  const [targetModule, setTargetModule] = useState<ImportModule | "">("");
   const [parsed, setParsed] = useState<{ headers: string[]; rows: Record<string, any>[] } | null>(null);
   const [columnMapping, setColumnMapping] = useState<Record<string, string>>({});
   const [importing, setImporting] = useState(false);
@@ -395,6 +402,15 @@ function CsvImportPanel({ file, onClear, parseXlsx }: {
     },
   });
 
+  // Re-suggest a column->field mapping whenever the file is parsed or the
+  // target module changes. Manual dropdown edits live in columnMapping and are
+  // intentionally NOT a dependency, so they survive until module/file changes.
+  useEffect(() => {
+    if (parsed && targetModule) {
+      setColumnMapping(buildDefaultMapping(parsed.headers, targetModule));
+    }
+  }, [parsed, targetModule]);
+
   const handleParse = async () => {
     const name = file.name.toLowerCase();
     if (name.endsWith(".xlsx") || name.endsWith(".xls")) {
@@ -402,25 +418,26 @@ function CsvImportPanel({ file, onClear, parseXlsx }: {
       if (result) {
         setParsed({ headers: result.headers, rows: result.rows as any });
         toast.success(`Parsed ${result.rows.length} rows`);
-        // Auto-map columns by matching header names
-        const mapping: Record<string, string> = {};
-        result.headers.forEach(h => { mapping[h] = h.toLowerCase().replace(/\s+/g, "_"); });
-        setColumnMapping(mapping);
       }
     } else {
       const text = await file.text();
       const result = parseCsvText(text);
       setParsed(result);
       toast.success(`Parsed ${result.rows.length} rows`);
-      const mapping: Record<string, string> = {};
-      result.headers.forEach(h => { mapping[h] = h.toLowerCase().replace(/\s+/g, "_"); });
-      setColumnMapping(mapping);
     }
   };
+
+  const fields = targetModule ? IMPORT_FIELDS[targetModule] : [];
+  const missingRequired = parsed && targetModule ? missingRequiredFields(targetModule, columnMapping) : [];
+  const sectionLabel = DATA_SECTIONS.find(s => s.value === targetModule)?.label ?? "...";
 
   const handleImport = () => {
     if (!parsed || !targetModule) {
       toast.error("Please select a data section and parse the file first");
+      return;
+    }
+    if (missingRequired.length > 0) {
+      toast.error(`Map the required field(s) first: ${missingRequired.map(f => f.label).join(", ")}`);
       return;
     }
     setImporting(true);
@@ -429,10 +446,14 @@ function CsvImportPanel({ file, onClear, parseXlsx }: {
       for (const [k, v] of Object.entries(row)) { obj[k] = String(v ?? ""); }
       return obj;
     });
+    // Only send columns the user actually mapped to a field.
+    const cleanMapping = Object.fromEntries(
+      Object.entries(columnMapping).filter(([, field]) => field !== IMPORT_SKIP),
+    );
     importMutation.mutate({
-      targetModule: targetModule as any,
+      targetModule,
       data: stringRows,
-      columnMapping,
+      columnMapping: cleanMapping,
     });
   };
 
@@ -475,35 +496,52 @@ function CsvImportPanel({ file, onClear, parseXlsx }: {
         ) : (
           <div className="space-y-3">
             <div className="text-sm text-muted-foreground">
-              Found <strong>{parsed.rows.length}</strong> rows with columns: {parsed.headers.join(", ")}
+              Found <strong>{parsed.rows.length}</strong> rows. Map each spreadsheet column to a{" "}
+              <strong>{sectionLabel}</strong> field so the data lands in the right place
+              (<span className="text-amber-600">*</span> = required):
             </div>
 
-            {/* Column mapping preview */}
-            <div className="max-h-32 overflow-y-auto text-xs border rounded p-2 bg-background">
-              <table className="w-full">
-                <thead>
-                  <tr>
-                    {parsed.headers.slice(0, 6).map(h => (
-                      <th key={h} className="text-left p-1 font-medium">{h}</th>
-                    ))}
-                  </tr>
-                </thead>
-                <tbody>
-                  {parsed.rows.slice(0, 3).map((row, i) => (
-                    <tr key={i}>
-                      {parsed.headers.slice(0, 6).map(h => (
-                        <td key={h} className="p-1 text-muted-foreground truncate max-w-[120px]">{String(row[h] || "")}</td>
+            {/* Column → field mapping */}
+            <div className="border rounded-lg divide-y max-h-72 overflow-y-auto">
+              {parsed.headers.map(h => {
+                const sample = parsed.rows.find(r => String(r[h] ?? "").trim() !== "")?.[h];
+                return (
+                  <div key={h} className="flex items-center gap-3 p-2">
+                    <div className="flex-1 min-w-0">
+                      <div className="text-sm font-medium truncate">{h}</div>
+                      <div className="text-xs text-muted-foreground truncate">
+                        e.g. {sample != null && String(sample).trim() !== "" ? String(sample) : "—"}
+                      </div>
+                    </div>
+                    <span className="text-muted-foreground text-xs shrink-0">→</span>
+                    <select
+                      value={columnMapping[h] ?? IMPORT_SKIP}
+                      onChange={(e) => setColumnMapping(m => ({ ...m, [h]: e.target.value }))}
+                      className="text-sm border rounded-md px-2 py-1 bg-background w-44 shrink-0"
+                    >
+                      <option value={IMPORT_SKIP}>— Don't import —</option>
+                      {fields.map(f => (
+                        <option key={f.key} value={f.key}>
+                          {f.label}{f.required ? " *" : ""}
+                        </option>
                       ))}
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-              {parsed.rows.length > 3 && <div className="text-center text-muted-foreground mt-1">... and {parsed.rows.length - 3} more rows</div>}
+                    </select>
+                  </div>
+                );
+              })}
             </div>
 
-            <Button onClick={handleImport} disabled={importing || !targetModule}>
+            {missingRequired.length > 0 && (
+              <div className="flex items-center gap-2 text-xs text-amber-600">
+                <AlertCircle className="h-3.5 w-3.5 shrink-0" />
+                Required field{missingRequired.length > 1 ? "s" : ""} not mapped:{" "}
+                {missingRequired.map(f => f.label).join(", ")}
+              </div>
+            )}
+
+            <Button onClick={handleImport} disabled={importing || !targetModule || missingRequired.length > 0}>
               {importing ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : <Upload className="h-4 w-4 mr-2" />}
-              Import {parsed.rows.length} rows into {targetModule || "..."}
+              Import {parsed.rows.length} rows into {sectionLabel}
             </Button>
           </div>
         )}

--- a/client/src/pages/Import.tsx
+++ b/client/src/pages/Import.tsx
@@ -53,18 +53,31 @@ const DATA_SECTIONS = [
   { value: "projects", label: "Projects" },
 ] as const;
 
-function parseCsvText(text: string): { headers: string[]; rows: Record<string, string>[] } {
-  const lines = text.split(/\r?\n/).filter(l => l.trim());
-  if (lines.length === 0) return { headers: [], rows: [] };
-  const sep = lines[0].includes("\t") ? "\t" : ",";
-  const headers = lines[0].split(sep).map(h => h.replace(/^"|"$/g, "").trim());
-  const rows = lines.slice(1).map(line => {
-    const vals = line.split(sep).map(v => v.replace(/^"|"$/g, "").trim());
-    const obj: Record<string, string> = {};
-    headers.forEach((h, i) => { obj[h] = vals[i] || ""; });
-    return obj;
-  });
-  return { headers, rows };
+type ParsedSheet = { headers: string[]; rows: Record<string, any>[] };
+type ParsedWorkbook = { sheetNames: string[]; sheets: Record<string, ParsedSheet> };
+
+// Parse a CSV/TSV/XLSX file into one or more sheets. SheetJS handles RFC 4180
+// CSV quoting (commas, escaped quotes and newlines inside quoted cells) and
+// multi-tab workbooks — both of which the previous naive splitter dropped.
+async function parseFileToWorkbook(file: File): Promise<ParsedWorkbook> {
+  const name = file.name.toLowerCase();
+  let workbook: XLSX.WorkBook;
+  if (name.endsWith(".xlsx") || name.endsWith(".xls")) {
+    const buffer = await file.arrayBuffer();
+    workbook = XLSX.read(buffer, { type: "array", raw: false });
+  } else {
+    // CSV / TSV / plain text — SheetJS detects the delimiter and quoting.
+    const text = await file.text();
+    workbook = XLSX.read(text, { type: "string", raw: false });
+  }
+  const sheets: Record<string, ParsedSheet> = {};
+  for (const sheetName of workbook.SheetNames) {
+    const ws = workbook.Sheets[sheetName];
+    const rows = XLSX.utils.sheet_to_json<Record<string, any>>(ws, { defval: "", raw: false });
+    const headers = rows.length > 0 ? Object.keys(rows[0]) : [];
+    sheets[sheetName] = { headers, rows };
+  }
+  return { sheetNames: workbook.SheetNames, sheets };
 }
 
 type DrivePreview = { fileId: string; fileName: string; detectedType: string; rowCount: number; supported: boolean };
@@ -447,15 +460,17 @@ function GoogleDriveFiles() {
   );
 }
 
-function CsvImportPanel({ file, onClear, parseXlsx }: {
+function CsvImportPanel({ file, onClear }: {
   file: File;
   onClear: () => void;
-  parseXlsx: (f: File) => Promise<{ headers: string[]; rows: Record<string, unknown>[] } | null>;
 }) {
   const [targetModule, setTargetModule] = useState<ImportModule | "">("");
-  const [parsed, setParsed] = useState<{ headers: string[]; rows: Record<string, any>[] } | null>(null);
+  const [workbook, setWorkbook] = useState<ParsedWorkbook | null>(null);
+  const [activeSheet, setActiveSheet] = useState<string>("");
   const [columnMapping, setColumnMapping] = useState<Record<string, string>>({});
   const [importing, setImporting] = useState(false);
+
+  const parsed: ParsedSheet | null = workbook && activeSheet ? workbook.sheets[activeSheet] ?? null : null;
 
   const importMutation = trpc.sheetsImport.importData.useMutation({
     onSuccess: (data) => {
@@ -471,34 +486,40 @@ function CsvImportPanel({ file, onClear, parseXlsx }: {
     },
   });
 
-  // Re-suggest a column->field mapping whenever the file is parsed or the
-  // target module changes. Manual dropdown edits live in columnMapping and are
-  // intentionally NOT a dependency, so they survive until module/file changes.
+  // Re-suggest a column->field mapping whenever the active sheet or target
+  // module changes. Manual dropdown edits live in columnMapping and are
+  // intentionally NOT a dependency, so they survive until sheet/module changes.
   useEffect(() => {
     if (parsed && targetModule) {
       setColumnMapping(buildDefaultMapping(parsed.headers, targetModule));
     }
-  }, [parsed, targetModule]);
+  }, [workbook, activeSheet, targetModule]);
 
   const handleParse = async () => {
-    const name = file.name.toLowerCase();
-    if (name.endsWith(".xlsx") || name.endsWith(".xls")) {
-      const result = await parseXlsx(file);
-      if (result) {
-        setParsed({ headers: result.headers, rows: result.rows as any });
-        toast.success(`Parsed ${result.rows.length} rows`);
+    try {
+      const wb = await parseFileToWorkbook(file);
+      if (wb.sheetNames.length === 0) {
+        toast.error("No sheets found in the file");
+        return;
       }
-    } else {
-      const text = await file.text();
-      const result = parseCsvText(text);
-      setParsed(result);
-      toast.success(`Parsed ${result.rows.length} rows`);
+      setWorkbook(wb);
+      setActiveSheet(wb.sheetNames[0]);
+      const first = wb.sheets[wb.sheetNames[0]];
+      toast.success(
+        `Parsed ${first.rows.length} rows` +
+          (wb.sheetNames.length > 1 ? ` from "${wb.sheetNames[0]}" (${wb.sheetNames.length} sheets)` : ""),
+      );
+    } catch (err) {
+      toast.error("Failed to parse file");
+      console.error("Parse error:", err);
     }
   };
 
   const fields = targetModule ? IMPORT_FIELDS[targetModule] : [];
   const missingRequired = parsed && targetModule ? missingRequiredFields(targetModule, columnMapping) : [];
   const sectionLabel = DATA_SECTIONS.find(s => s.value === targetModule)?.label ?? "...";
+  const ignoredColumns = parsed ? parsed.headers.filter(h => (columnMapping[h] ?? IMPORT_SKIP) === IMPORT_SKIP) : [];
+  const mappedCount = parsed ? parsed.headers.length - ignoredColumns.length : 0;
 
   const handleImport = () => {
     if (!parsed || !targetModule) {
@@ -564,6 +585,26 @@ function CsvImportPanel({ file, onClear, parseXlsx }: {
           </Button>
         ) : (
           <div className="space-y-3">
+            {workbook && workbook.sheetNames.length > 1 && (
+              <div className="flex items-center gap-2 rounded-md border border-amber-200 bg-amber-50 dark:bg-amber-950/30 p-2">
+                <AlertCircle className="h-4 w-4 text-amber-600 shrink-0" />
+                <span className="text-xs text-amber-700 dark:text-amber-300">
+                  This file has {workbook.sheetNames.length} sheets. Importing one at a time — choose which:
+                </span>
+                <select
+                  value={activeSheet}
+                  onChange={(e) => setActiveSheet(e.target.value)}
+                  className="text-xs border rounded-md px-2 py-1 bg-background ml-auto shrink-0"
+                >
+                  {workbook.sheetNames.map((name) => (
+                    <option key={name} value={name}>
+                      {name} ({workbook.sheets[name]?.rows.length ?? 0})
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
+
             <div className="text-sm text-muted-foreground">
               Found <strong>{parsed.rows.length}</strong> rows. Map each spreadsheet column to a{" "}
               <strong>{sectionLabel}</strong> field so the data lands in the right place
@@ -607,6 +648,18 @@ function CsvImportPanel({ file, onClear, parseXlsx }: {
                 {missingRequired.map(f => f.label).join(", ")}
               </div>
             )}
+
+            {/* Pre-flight transparency: exactly what will and won't be written. */}
+            <div className="rounded-md border bg-muted/40 p-2 text-xs space-y-1">
+              <div className="text-muted-foreground">
+                Importing <strong>{mappedCount}</strong> of {parsed.headers.length} column{parsed.headers.length === 1 ? "" : "s"} into <strong>{sectionLabel}</strong>.
+              </div>
+              {ignoredColumns.length > 0 && (
+                <div className="text-amber-600">
+                  Will be ignored: {ignoredColumns.join(", ")}
+                </div>
+              )}
+            </div>
 
             <Button onClick={handleImport} disabled={importing || !targetModule || missingRequired.length > 0}>
               {importing ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : <Upload className="h-4 w-4 mr-2" />}
@@ -792,26 +845,6 @@ export default function Import() {
     setCsvFile(file);
     toast.success(`File "${file.name}" ready for upload`);
   }, [isImageFile, handleImageFile]);
-
-  const parseXlsxFile = useCallback(async (file: File): Promise<{ headers: string[]; rows: Record<string, unknown>[] } | null> => {
-    try {
-      const buffer = await file.arrayBuffer();
-      const workbook = XLSX.read(buffer, { type: "array" });
-      const firstSheetName = workbook.SheetNames[0];
-      if (!firstSheetName) {
-        toast.error("No sheets found in the workbook");
-        return null;
-      }
-      const worksheet = workbook.Sheets[firstSheetName];
-      const jsonData = XLSX.utils.sheet_to_json<Record<string, unknown>>(worksheet);
-      const headers = jsonData.length > 0 ? Object.keys(jsonData[0]) : [];
-      return { headers, rows: jsonData };
-    } catch (err) {
-      toast.error("Failed to parse XLSX file");
-      console.error("XLSX parse error:", err);
-      return null;
-    }
-  }, []);
 
   const getTypeBadgeColor = (type: string) => {
     switch (type) {
@@ -1149,7 +1182,7 @@ export default function Import() {
           )}
 
           {csvFile && !imagePreviewUrl && (
-            <CsvImportPanel file={csvFile} onClear={() => setCsvFile(null)} parseXlsx={parseXlsxFile} />
+            <CsvImportPanel file={csvFile} onClear={() => setCsvFile(null)} />
           )}
         </CardContent>
       </Card>

--- a/client/src/pages/Import.tsx
+++ b/client/src/pages/Import.tsx
@@ -28,6 +28,7 @@ import { useLocation, useSearch } from "wouter";
 import {
   IMPORT_FIELDS,
   IMPORT_SKIP,
+  DRIVE_IMPORT_TYPES,
   buildDefaultMapping,
   missingRequiredFields,
   type ImportModule,
@@ -66,25 +67,20 @@ function parseCsvText(text: string): { headers: string[]; rows: Record<string, s
   return { headers, rows };
 }
 
-function DriveFileBrowser({ onSyncAll }: { onSyncAll: () => void }) {
-  const [showBrowser, setShowBrowser] = useState(true);
+type DrivePreview = { fileId: string; fileName: string; detectedType: string; rowCount: number; supported: boolean };
+
+function DriveFileBrowser({ onImport }: { onImport: (selections: { fileId: string; type: string }[]) => void }) {
+  const [showBrowser] = useState(true);
   const { data: spreadsheets, isLoading } = trpc.sheetsImport.listSpreadsheets.useQuery(undefined, { enabled: showBrowser });
+  const utils = trpc.useUtils();
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
-  const [syncing, setSyncing] = useState(false);
   const [search, setSearch] = useState("");
 
-  const syncSelectedMutation = trpc.sheetsImport.syncGoogleDrive.useMutation({
-    onSuccess: (data) => {
-      setSyncing(false);
-      const totalImported = data.results.reduce((sum: number, r: any) => sum + r.imported, 0);
-      toast.success(`Imported ${totalImported} records from ${selectedIds.size} files`);
-      setSelectedIds(new Set());
-    },
-    onError: (error) => {
-      setSyncing(false);
-      toast.error(error.message);
-    },
-  });
+  // Confirmation step: previews from the server + the user's per-file choice
+  // (a DRIVE_IMPORT_TYPES value, or "" to skip the file).
+  const [previewing, setPreviewing] = useState(false);
+  const [previews, setPreviews] = useState<DrivePreview[] | null>(null);
+  const [choices, setChoices] = useState<Record<string, string>>({});
 
   const toggleFile = (id: string) => {
     const next = new Set(selectedIds);
@@ -99,6 +95,78 @@ function DriveFileBrowser({ onSyncAll }: { onSyncAll: () => void }) {
     : files;
   const allFilteredSelected = filteredFiles.length > 0 && filteredFiles.every((f: any) => selectedIds.has(f.id));
 
+  const runPreview = async (fileIds?: string[]) => {
+    setPreviewing(true);
+    try {
+      const res = await utils.sheetsImport.previewGoogleDrive.fetch(
+        fileIds && fileIds.length ? { fileIds } : {},
+      );
+      const rows = res.previews as DrivePreview[];
+      setPreviews(rows);
+      // Default each file to its detected type when we can import it, else skip.
+      const next: Record<string, string> = {};
+      rows.forEach((p) => { next[p.fileId] = p.supported ? p.detectedType : ""; });
+      setChoices(next);
+    } catch (error: any) {
+      toast.error(error.message);
+    } finally {
+      setPreviewing(false);
+    }
+  };
+
+  // ---- Confirmation step ----
+  if (previews) {
+    const importable = previews.filter((p) => choices[p.fileId]);
+    return (
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <h4 className="text-sm font-medium">Confirm destinations</h4>
+          <Button variant="ghost" size="sm" onClick={() => setPreviews(null)}>Back</Button>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          We detected where each sheet should go. Review and adjust before importing — nothing is written until you confirm.
+        </p>
+
+        <div className="border rounded-lg divide-y max-h-72 overflow-y-auto">
+          {previews.map((p) => (
+            <div key={p.fileId} className="flex items-center gap-3 p-3">
+              <FileSpreadsheet className="h-4 w-4 text-green-600 shrink-0" />
+              <div className="flex-1 min-w-0">
+                <div className="text-sm font-medium truncate">{p.fileName}</div>
+                <div className="text-xs text-muted-foreground">
+                  {p.rowCount} row{p.rowCount === 1 ? "" : "s"}
+                  {p.detectedType === "unknown" && " · type not recognised"}
+                  {p.detectedType === "error" && " · could not read sheet"}
+                </div>
+              </div>
+              <span className="text-muted-foreground text-xs shrink-0">→</span>
+              <select
+                value={choices[p.fileId] ?? ""}
+                onChange={(e) => setChoices((c) => ({ ...c, [p.fileId]: e.target.value }))}
+                className="text-sm border rounded-md px-2 py-1 bg-background w-44 shrink-0"
+              >
+                <option value="">— Don't import —</option>
+                {DRIVE_IMPORT_TYPES.map((t) => (
+                  <option key={t.value} value={t.value}>{t.label}</option>
+                ))}
+              </select>
+            </div>
+          ))}
+        </div>
+
+        <Button
+          className="w-full"
+          disabled={importable.length === 0}
+          onClick={() => onImport(importable.map((p) => ({ fileId: p.fileId, type: choices[p.fileId] })))}
+        >
+          <CloudDownload className="h-4 w-4 mr-2" />
+          Import {importable.length} file{importable.length === 1 ? "" : "s"}
+        </Button>
+      </div>
+    );
+  }
+
+  // ---- Browse + select step ----
   return (
     <div className="space-y-3">
       <div className="flex items-center justify-between">
@@ -117,8 +185,9 @@ function DriveFileBrowser({ onSyncAll }: { onSyncAll: () => void }) {
           }}>
             {allFilteredSelected ? "Deselect All" : "Select All"}
           </Button>
-          <Button variant="outline" size="sm" onClick={onSyncAll}>
-            <RefreshCw className="h-3 w-3 mr-1" /> Sync All
+          <Button variant="outline" size="sm" disabled={previewing || files.length === 0} onClick={() => runPreview()}>
+            {previewing && selectedIds.size === 0 ? <Loader2 className="h-3 w-3 mr-1 animate-spin" /> : <RefreshCw className="h-3 w-3 mr-1" />}
+            Review All
           </Button>
         </div>
       </div>
@@ -174,17 +243,17 @@ function DriveFileBrowser({ onSyncAll }: { onSyncAll: () => void }) {
 
       {selectedIds.size > 0 && (
         <Button
-          onClick={() => { setSyncing(true); syncSelectedMutation.mutate(); }}
-          disabled={syncing}
+          onClick={() => runPreview([...selectedIds])}
+          disabled={previewing}
           className="w-full"
         >
-          {syncing ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : <CloudDownload className="h-4 w-4 mr-2" />}
-          Sync {selectedIds.size} Selected File{selectedIds.size > 1 ? "s" : ""}
+          {previewing ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : <CloudDownload className="h-4 w-4 mr-2" />}
+          Review {selectedIds.size} Selected File{selectedIds.size > 1 ? "s" : ""}
         </Button>
       )}
 
       <p className="text-xs text-muted-foreground text-center">
-        Select specific files to sync, or click "Sync All" to import everything.
+        Select specific files, or click "Review All" — you'll confirm where each sheet goes before importing.
       </p>
     </div>
   );
@@ -647,10 +716,10 @@ export default function Import() {
     }
   };
 
-  const handleSync = () => {
+  const handleImportSelections = (selections: { fileId: string; type: string }[]) => {
     setSyncState("syncing");
     setSyncResults([]);
-    syncMutation.mutate();
+    syncMutation.mutate({ selections } as any);
   };
 
   const handleReset = () => {
@@ -853,7 +922,7 @@ export default function Import() {
                 </Button>
               </div>
 
-              <DriveFileBrowser onSyncAll={handleSync} />
+              <DriveFileBrowser onImport={handleImportSelections} />
 
               {/* Previously imported — persisted sync history */}
               {syncHistory && syncHistory.length > 0 && (

--- a/client/src/pages/finance/RdTaxCredit.tsx
+++ b/client/src/pages/finance/RdTaxCredit.tsx
@@ -73,7 +73,7 @@ export default function RdTaxCredit() {
           <h1 className="text-2xl font-bold flex items-center gap-2">
             <FlaskConical className="h-6 w-6" /> R&D Tax Credit
           </h1>
-          <p className="text-muted-foreground">IRC Section 41 â Calculate and file R&D tax credits (Form 6765)</p>
+          <p className="text-muted-foreground">IRC Section 41 — Calculate and file R&D tax credits (Form 6765)</p>
         </div>
         <Button onClick={() => setShowNewStudy(true)}>
           <Plus className="h-4 w-4 mr-2" /> New Study
@@ -119,7 +119,7 @@ function StudyList({ onSelect }: { onSelect: (id: number) => void }) {
                   <Badge className={statusColors[study.status] || ""}>{study.status.replace("_", " ")}</Badge>
                   <Badge variant="outline">{study.calculationMethod === "asc" ? "ASC Method" : "Regular Credit"}</Badge>
                 </div>
-                <p className="text-sm text-muted-foreground">Tax Year {study.taxYear} â Form {study.formNumber || "6765"}</p>
+                <p className="text-sm text-muted-foreground">Tax Year {study.taxYear} — Form {study.formNumber || "6765"}</p>
               </div>
               <div className="text-right space-y-1">
                 <p className="text-2xl font-bold text-green-600">{fmt(study.netCredit)}</p>
@@ -184,8 +184,8 @@ function NewStudyDialog({ open, onOpenChange }: { open: boolean; onOpenChange: (
             <Select value={form.calculationMethod} onValueChange={(v) => setForm(f => ({ ...f, calculationMethod: v as any }))}>
               <SelectTrigger><SelectValue /></SelectTrigger>
               <SelectContent>
-                <SelectItem value="asc">Alternative Simplified Credit (ASC) â 14% rate</SelectItem>
-                <SelectItem value="regular">Regular Credit (RC) â 20% rate</SelectItem>
+                <SelectItem value="asc">Alternative Simplified Credit (ASC) — 14% rate</SelectItem>
+                <SelectItem value="regular">Regular Credit (RC) — 20% rate</SelectItem>
               </SelectContent>
             </Select>
           </div>
@@ -263,7 +263,7 @@ function StudyDetail({ studyId, onBack }: { studyId: number; onBack: () => void 
           <Button variant="ghost" size="sm" onClick={onBack}><ArrowLeft className="h-4 w-4" /></Button>
           <div>
             <h1 className="text-2xl font-bold">{study.studyName}</h1>
-            <p className="text-muted-foreground">Tax Year {study.taxYear} â {study.calculationMethod === "asc" ? "Alternative Simplified Credit" : "Regular Credit"}</p>
+            <p className="text-muted-foreground">Tax Year {study.taxYear} — {study.calculationMethod === "asc" ? "Alternative Simplified Credit" : "Regular Credit"}</p>
           </div>
           <Badge className={statusColors[study.status] || ""}>{study.status.replace("_", " ")}</Badge>
         </div>
@@ -280,7 +280,7 @@ function StudyDetail({ studyId, onBack }: { studyId: number; onBack: () => void 
           </Select>
           <div className="flex items-center gap-2 text-sm">
             <Switch id="elect280c" checked={elect280C} onCheckedChange={setElect280C} />
-            <Label htmlFor="elect280c" className="cursor-pointer whitespace-nowrap">Â§280C Election</Label>
+            <Label htmlFor="elect280c" className="cursor-pointer whitespace-nowrap">§280C Election</Label>
           </div>
           <Button onClick={() => calculateCredit.mutate({ studyId, elect280CReduction: elect280C })} disabled={calculateCredit.isPending}>
             {calculateCredit.isPending ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : <Calculator className="h-4 w-4 mr-2" />}
@@ -307,7 +307,7 @@ function StudyDetail({ studyId, onBack }: { studyId: number; onBack: () => void 
           <p className="text-xl font-bold">{fmt(study.grossCredit)}</p>
         </CardContent></Card>
         <Card><CardContent className="pt-4 text-center">
-          <p className="text-xs text-muted-foreground">Â§280C Reduction</p>
+          <p className="text-xs text-muted-foreground">§280C Reduction</p>
           <p className="text-xl font-bold text-red-500">{fmt(study.section280CReduction)}</p>
         </CardContent></Card>
         <Card className="border-green-200 bg-green-50"><CardContent className="pt-4 text-center">
@@ -457,7 +457,7 @@ function ProjectsTab({ studyId, projects, onRefresh }: { studyId: number; projec
         <DialogContent className="max-w-2xl max-h-[80vh] overflow-y-auto">
           <DialogHeader>
             <DialogTitle>Add R&D Project</DialogTitle>
-            <DialogDescription>Document the project and complete the IRC Â§41 four-part test.</DialogDescription>
+            <DialogDescription>Document the project and complete the IRC §41 four-part test.</DialogDescription>
           </DialogHeader>
           <div className="space-y-4">
             <div className="grid grid-cols-2 gap-4">
@@ -468,7 +468,7 @@ function ProjectsTab({ studyId, projects, onRefresh }: { studyId: number; projec
 
             {/* Four-Part Test */}
             <div className="border rounded-lg p-4 space-y-4">
-              <h4 className="font-semibold flex items-center gap-2"><ClipboardCheck className="h-4 w-4" /> IRC Â§41 Four-Part Test</h4>
+              <h4 className="font-semibold flex items-center gap-2"><ClipboardCheck className="h-4 w-4" /> IRC §41 Four-Part Test</h4>
 
               {[
                 { key: "technologicalInNature", notesKey: "technologicalNatureNotes", label: "1. Technological in Nature", desc: "Does the activity rely on principles of physical/biological science, engineering, or computer science?" },
@@ -501,7 +501,7 @@ function ProjectsTab({ studyId, projects, onRefresh }: { studyId: number; projec
 
               <div className="border-t pt-3">
                 {fourPartTestPasses(form) ? (
-                  <Badge className="bg-green-100 text-green-700"><CheckCircle2 className="h-3 w-3 mr-1" /> All four parts satisfied â project qualifies</Badge>
+                  <Badge className="bg-green-100 text-green-700"><CheckCircle2 className="h-3 w-3 mr-1" /> All four parts satisfied — project qualifies</Badge>
                 ) : (
                   <Badge className="bg-yellow-100 text-yellow-700">Complete all four parts for the project to qualify</Badge>
                 )}
@@ -607,8 +607,8 @@ function ExpensesTab({ studyId, projects, expenses, onRefresh }: { studyId: numb
             {expenses.map((exp) => (
               <TableRow key={exp.id}>
                 <TableCell><Badge variant="outline">{categoryLabels[exp.category] || exp.category}</Badge></TableCell>
-                <TableCell className="max-w-xs truncate">{exp.description || "â"}</TableCell>
-                <TableCell>{exp.employeeName || exp.vendorName || "â"}</TableCell>
+                <TableCell className="max-w-xs truncate">{exp.description || "—"}</TableCell>
+                <TableCell>{exp.employeeName || exp.vendorName || "—"}</TableCell>
                 <TableCell className="text-right">{fmt(exp.grossAmount)}</TableCell>
                 <TableCell className="text-right">
                   <InlineRdPercent
@@ -672,7 +672,7 @@ function ExpensesTab({ studyId, projects, expenses, onRefresh }: { studyId: numb
               <div><Label>Qualified Amount</Label><Input value={computeQualified()} readOnly className="bg-muted" /></div>
             </div>
             {form.category === "contract_research" && (
-              <p className="text-xs text-muted-foreground">Contract research expenses are qualified at 65% per IRC Â§41(b)(3).</p>
+              <p className="text-xs text-muted-foreground">Contract research expenses are qualified at 65% per IRC §41(b)(3).</p>
             )}
           </div>
           <DialogFooter>
@@ -715,18 +715,18 @@ function Form6765Tab({ studyId }: { studyId: number }) {
     <div className="space-y-6">
       <Card>
         <CardHeader>
-          <CardTitle className="flex items-center gap-2"><FileText className="h-5 w-5" /> IRS Form 6765 â Credit for Increasing Research Activities</CardTitle>
-          <CardDescription>Tax Year {form.taxYear} â {form.calculationMethod === "asc" ? "Section B (Alternative Simplified Credit)" : "Section A (Regular Credit)"}</CardDescription>
+          <CardTitle className="flex items-center gap-2"><FileText className="h-5 w-5" /> IRS Form 6765 — Credit for Increasing Research Activities</CardTitle>
+          <CardDescription>Tax Year {form.taxYear} — {form.calculationMethod === "asc" ? "Section B (Alternative Simplified Credit)" : "Section A (Regular Credit)"}</CardDescription>
         </CardHeader>
         <CardContent className="space-y-6">
           {/* QRE Summary */}
           <div className="border rounded-lg p-4 space-y-3">
             <h4 className="font-semibold">Qualified Research Expenses</h4>
             <div className="grid grid-cols-2 gap-2 text-sm">
-              <span className="text-muted-foreground">Line 1 â Wages for qualified services</span><span className="text-right font-mono">{fmt(form.line1_wages)}</span>
-              <span className="text-muted-foreground">Line 2 â Cost of supplies</span><span className="text-right font-mono">{fmt(form.line2_supplies)}</span>
-              <span className="text-muted-foreground">Line 3 â Contract research (65%)</span><span className="text-right font-mono">{fmt(form.line3_contractResearch)}</span>
-              <span className="text-muted-foreground font-semibold">Line 5 â Total QREs</span><span className="text-right font-mono font-semibold">{fmt(form.line5_totalQre)}</span>
+              <span className="text-muted-foreground">Line 1 — Wages for qualified services</span><span className="text-right font-mono">{fmt(form.line1_wages)}</span>
+              <span className="text-muted-foreground">Line 2 — Cost of supplies</span><span className="text-right font-mono">{fmt(form.line2_supplies)}</span>
+              <span className="text-muted-foreground">Line 3 — Contract research (65%)</span><span className="text-right font-mono">{fmt(form.line3_contractResearch)}</span>
+              <span className="text-muted-foreground font-semibold">Line 5 — Total QREs</span><span className="text-right font-mono font-semibold">{fmt(form.line5_totalQre)}</span>
             </div>
           </div>
 
@@ -742,12 +742,12 @@ function Form6765Tab({ studyId }: { studyId: number }) {
                   <span className="text-muted-foreground">Average Prior QRE</span><span className="text-right font-mono">{fmt(form.averagePriorQre)}</span>
                 </>
               )}
-              <span className="text-muted-foreground">Line 6 â Base amount</span><span className="text-right font-mono">{fmt(form.line6_baseAmount)}</span>
-              <span className="text-muted-foreground">Line 7 â QREs over base</span><span className="text-right font-mono">{fmt(form.line7_excessQre)}</span>
-              <span className="text-muted-foreground">Line 8 â Credit rate</span><span className="text-right font-mono">{((parseFloat(String(form.line8_creditRate ?? 0))) * 100).toFixed(0)}%</span>
-              <span className="text-muted-foreground font-semibold">Line 9 â Gross credit</span><span className="text-right font-mono font-semibold">{fmt(form.line9_grossCredit)}</span>
-              <span className="text-muted-foreground">Line 10 â Â§280C reduction</span><span className="text-right font-mono text-red-500">{fmt(form.line10_section280C)}</span>
-              <span className="text-muted-foreground font-bold">Line 11 â Net credit</span><span className="text-right font-mono font-bold text-green-600 text-lg">{fmt(form.line11_netCredit)}</span>
+              <span className="text-muted-foreground">Line 6 — Base amount</span><span className="text-right font-mono">{fmt(form.line6_baseAmount)}</span>
+              <span className="text-muted-foreground">Line 7 — QREs over base</span><span className="text-right font-mono">{fmt(form.line7_excessQre)}</span>
+              <span className="text-muted-foreground">Line 8 — Credit rate</span><span className="text-right font-mono">{((parseFloat(String(form.line8_creditRate ?? 0))) * 100).toFixed(0)}%</span>
+              <span className="text-muted-foreground font-semibold">Line 9 — Gross credit</span><span className="text-right font-mono font-semibold">{fmt(form.line9_grossCredit)}</span>
+              <span className="text-muted-foreground">Line 10 — §280C reduction</span><span className="text-right font-mono text-red-500">{fmt(form.line10_section280C)}</span>
+              <span className="text-muted-foreground font-bold">Line 11 — Net credit</span><span className="text-right font-mono font-bold text-green-600 text-lg">{fmt(form.line11_netCredit)}</span>
             </div>
           </div>
 
@@ -770,7 +770,7 @@ function Form6765Tab({ studyId }: { studyId: number }) {
   );
 }
 
-// Inline R&D % editor â click to edit, blur or Enter to save.
+// Inline R&D % editor — click to edit, blur or Enter to save.
 function InlineRdPercent({ value, onSave }: { value: number; onSave: (v: number) => void }) {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(String(value));
@@ -786,7 +786,6 @@ function InlineRdPercent({ value, onSave }: { value: number; onSave: (v: number)
       </button>
     );
   }
-
   const commit = () => {
     const n = parseFloat(draft);
     if (!isNaN(n) && n !== value) onSave(Math.max(0, Math.min(100, n)));
@@ -821,82 +820,76 @@ function ImportFromQBButton({ studyId, projects, onRefresh }: {
   onRefresh: () => void;
 }) {
   const [open, setOpen] = useState(false);
-      min={0}
-      max={100}
-      value={draft}
-      onChange={(e) => setDraft(e.target.value)}
-      onBlur={commit}
-      onKeyDown={(e) => {
-        if (e.key === "Enter") commit();
-        if (e.key === "Escape") setEditing(false);
-      }}
-      className="w-16 rounded border bg-background px-1 text-right text-sm"
-    />
-  );
-}
+  const [projectId, setProjectId] = useState("");
+  const [startDate, setStartDate] = useState(() => {
+    const d = new Date(); d.setMonth(0, 1); return d.toISOString().slice(0, 10);
+  });
+  const [endDate, setEndDate] = useState(() => new Date().toISOString().slice(0, 10));
+  const [category, setCategory] = useState<QBImportCategory>("wages");
 
-// ============================================
-// IMPORT FROM QB BUTTON (Issue #270)
-// ============================================
-type QBImportCategory = "wages" | "supplies" | "contract_research" | "cloud_computing";
+  const importMutation = trpc.rdTaxCredit.importFromQuickBooks.useMutation({
+    onSuccess: (data: any) => {
+      toast.success(`Imported ${data.imported ?? 0} expense(s) from QuickBooks`);
+      setOpen(false);
+      onRefresh();
+    },
+    onError: (e: any) => toast.error(e.message),
+  });
 
-function ImportFromQBButton({ studyId, projects, onRefresh }: {
-  studyId: number;
-  projects: Array<{ id?: number | null; projectName?: string | null }>;
-  onRefresh: () => void;
-}) {
-  const [open, setOpen] = useState(false);
-      min={0}
-      max={100}
-      value={draft}
-      onChange={(e) => setDraft(e.target.value)}
-      onBlur={commit}
-      onKeyDown={(e) => {
-        if (e.key === "Enter") commit();
-        if (e.key === "Escape") setEditing(false);
-      }}
-      className="w-16 rounded border bg-background px-1 text-right text-sm"
-    />
-  );
-}
-
-// ============================================
-// IMPORT FROM QB BUTTON (Issue #270)
-// ============================================
-type QBImportCategory = "wages" | "supplies" | "contract_research" | "cloud_computing";
-
-function ImportFromQBButton({ studyId, projects, onRefresh }: {
-  studyId: number;
-  projects: Array<{ id?: number | null; projectName?: string | null }>;
-  onRefresh: () => void;
-}) {
-  const [open, setOpen] = useState(false);
-      min={0}
-      max={100}
-      value={draft}
-      onChange={(e) => setDraft(e.target.value)}
-      onBlur={commit}
-      onKeyDown={(e) => {
-        if (e.key === "Enter") commit();
-        if (e.key === "Escape") setEditing(false);
-      }}
-      className="w-16 rounded border bg-background px-1 text-right text-sm"
-    />
-  );
-}
-
-// ============================================
-// IMPORT FROM QB BUTTON (Issue #270)
+  return (
+    <>
+      <Button size="sm" variant="outline" onClick={() => setOpen(true)}>
+        <Download className="h-4 w-4 mr-1" /> Import from QuickBooks
+      </Button>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>Import from QuickBooks</DialogTitle>
+            <DialogDescription>
+              Pull posted QuickBooks transactions matching the date range and category.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div>
+              <Label>Project</Label>
+              <Select value={projectId} onValueChange={setProjectId}>
+                <SelectTrigger><SelectValue placeholder="Select project" /></SelectTrigger>
+                <SelectContent>
+                  {projects.map((p) => (
+                    <SelectItem key={p.id} value={String(p.id)}>{p.projectName}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
             <div className="grid grid-cols-2 gap-4">
               <div><Label>Start Date</Label><Input type="date" value={startDate} onChange={e => setStartDate(e.target.value)} /></div>
               <div><Label>End Date</Label><Input type="date" value={endDate} onChange={e => setEndDate(e.target.value)} /></div>
+            </div>
+            <div>
+              <Label>Category</Label>
+              <Select value={category} onValueChange={(v) => setCategory(v as QBImportCategory)}>
+                <SelectTrigger><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="wages">Employee Wages</SelectItem>
+                  <SelectItem value="supplies">Supplies</SelectItem>
+                  <SelectItem value="contract_research">Contract Research (65%)</SelectItem>
+                  <SelectItem value="cloud_computing">Cloud Computing</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setOpen(false)}>Cancel</Button>
+            <Button
+              onClick={() => importMutation.mutate({ studyId, projectId: parseInt(projectId), startDate, endDate, category })}
+              disabled={!projectId || importMutation.isPending}
+            >
+              {importMutation.isPending && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+              Import Expenses
+            </Button>
+          </DialogFooter>
+        </DialogContent>
       </Dialog>
     </>
-  );
-}
-  );
-}
-  );
-}
   );
 }

--- a/client/src/pages/settings/ShopifySettings.tsx
+++ b/client/src/pages/settings/ShopifySettings.tsx
@@ -4,7 +4,8 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
-import { Switch } from "@/components/ui/switch";import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { trpc } from "@/lib/trpc";
@@ -422,13 +423,16 @@ function AddLocationMappingButton({ storeId }: { storeId: number }) {
               onClick={() => createMapping.mutate({
                 storeId,
                 shopifyLocationId,
-                                warehouseId: parseInt(warehouseId),
+                warehouseId: parseInt(warehouseId),
               })}
               disabled={!shopifyLocationId || !warehouseId || createMapping.isPending}
             >
+              {createMapping.isPending && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
               Create Mapping
             </Button>
           </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </>
   );
 }

--- a/scripts/strict-ratchet.mjs
+++ b/scripts/strict-ratchet.mjs
@@ -45,9 +45,15 @@ function runStrict() {
     if (output.trim()) console.error(output.trim());
     process.exit(2);
   }
-  // tsc exits 0 with no errors, 1 with type errors.
-  // Other exit codes (e.g. 2 for config/options errors) are fatal.
-  if (r.status !== 0 && r.status !== 1) {
+  // tsc's ExitStatus for a completed typecheck:
+  //   0 = Success
+  //   1 = DiagnosticsPresent_OutputsSkipped   (errors, nothing emitted)
+  //   2 = DiagnosticsPresent_OutputsGenerated (errors, but output emitted —
+  //       e.g. the incremental .tsbuildinfo from `incremental: true`, which
+  //       happens on a fresh checkout like CI where no buildinfo exists yet)
+  // All three produce parseable diagnostics. Codes >= 3 (InvalidProject /
+  // ProjectReferenceCycle) are genuine config/tooling failures and stay fatal.
+  if (r.status !== 0 && r.status !== 1 && r.status !== 2) {
     console.error(
       `Strict typecheck failed with exit code ${r.status}. This usually indicates a tooling/config issue (e.g. pnpm not available or invalid TypeScript config).`,
     );

--- a/server/routers.ts
+++ b/server/routers.ts
@@ -251,12 +251,15 @@ export function detectSheetType(headers: string[]): string {
   return 'unknown';
 }
 
-// Helper to generate unique numbers
+// Helper to generate unique reference numbers (e.g. EMP-2606-1234). Uses a
+// CSPRNG for the suffix — not because these are secrets, but to satisfy static
+// analysis and avoid Math.random()'s modulo bias.
 export function generateNumber(prefix: string) {
   const date = new Date();
   const year = date.getFullYear().toString().slice(-2);
   const month = (date.getMonth() + 1).toString().padStart(2, '0');
-  const random = Math.floor(Math.random() * 10000).toString().padStart(4, '0');
+  const crypto = require('crypto');
+  const random = crypto.randomInt(10000).toString().padStart(4, '0');
   return `${prefix}-${year}${month}-${random}`;
 }
 // Secure password hashing helpers using scrypt

--- a/server/routers.ts
+++ b/server/routers.ts
@@ -224,6 +224,32 @@ async function getValidGoogleToken(userId: number): Promise<{ accessToken: strin
   return { accessToken: token.accessToken };
 }
 
+// Data types the Google Drive auto-sync importer knows how to write. Anything
+// else (unknown / invoices / purchase_orders) is surfaced in the preview but
+// cannot be imported without manual handling.
+const DRIVE_SUPPORTED_TYPES = [
+  'vendors', 'customers', 'products', 'employees',
+  'raw_materials', 'crm_contacts', 'crm_deals', 'fundraising',
+] as const;
+
+// Detect the destination type for a sheet from its (lowercased) header row.
+// Shared by previewGoogleDrive (detect-only) and syncGoogleDrive (detect+import)
+// so the suggestion the user confirms is exactly what gets imported.
+export function detectSheetType(headers: string[]): string {
+  if (headers.some((h) => h.includes('vendor') || h.includes('supplier'))) return 'vendors';
+  if (headers.some((h) => h.includes('customer') || h.includes('client') || h.includes('buyer'))) return 'customers';
+  if (headers.some((h) => h.includes('sku') || h.includes('product') || h.includes('item'))) return 'products';
+  if (headers.some((h) => h.includes('invoice') || h.includes('bill'))) return 'invoices';
+  if (headers.some((h) => h.includes('employee') || h.includes('team') || h.includes('staff'))) return 'employees';
+  if (headers.some((h) => h.includes('ingredient') || h.includes('raw material') || h.includes('material'))) return 'raw_materials';
+  if (headers.some((h) => h.includes('order') || h.includes('po') || h.includes('purchase'))) return 'purchase_orders';
+  if (headers.some((h) => h.includes('price') || h.includes('cost') || h.includes('rate'))) return 'products';
+  if (headers.some((h) => h.includes('contact') || h.includes('lead') || h.includes('prospect') || h.includes('pipeline'))) return 'crm_contacts';
+  if (headers.some((h) => h.includes('investor') || h.includes('fund') || h.includes('commitment') || h.includes('round') || h.includes('series'))) return 'fundraising';
+  if (headers.some((h) => h.includes('deal') || h.includes('opportunity') || h.includes('stage'))) return 'crm_deals';
+  return 'unknown';
+}
+
 // Helper to generate unique numbers
 export function generateNumber(prefix: string) {
   const date = new Date();
@@ -4761,8 +4787,80 @@ ONLY return the JSON array, no other text.`;
       }),
 
     // Sync all Google Drive spreadsheets automatically
+    // Detect the destination type of each spreadsheet WITHOUT importing, so the
+    // UI can let the user confirm or override the target before any write.
+    previewGoogleDrive: protectedProcedure
+      .input(z.object({ fileIds: z.array(z.string()).optional() }).optional())
+      .query(async ({ input, ctx }) => {
+        const { accessToken, error: tokenError } = await getValidGoogleToken(ctx.user.id);
+        if (tokenError || !accessToken) {
+          throw new TRPCError({ code: 'PRECONDITION_FAILED', message: tokenError || 'Google not connected. Go to Settings to connect your Google account.' });
+        }
+
+        const sheetsResponse = await fetch(
+          `https://www.googleapis.com/drive/v3/files?q=(mimeType='application/vnd.google-apps.spreadsheet' or mimeType='application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' or mimeType='text/csv')&fields=files(id,name,modifiedTime,mimeType)&orderBy=modifiedTime desc&pageSize=100`,
+          { headers: { Authorization: `Bearer ${accessToken}` } },
+        );
+        if (!sheetsResponse.ok) {
+          throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: 'Failed to list Google Sheets from Drive' });
+        }
+        const sheetsData = await sheetsResponse.json();
+        let files = sheetsData.files || [];
+        const wanted = input?.fileIds && input.fileIds.length > 0 ? new Set(input.fileIds) : null;
+        if (wanted) files = files.filter((f: any) => wanted.has(f.id));
+
+        const previews: { fileId: string; fileName: string; detectedType: string; rowCount: number; supported: boolean }[] = [];
+        for (const file of files) {
+          try {
+            let data: any;
+            const dataResponse = await fetch(
+              `https://sheets.googleapis.com/v4/spreadsheets/${file.id}/values/Sheet1?majorDimension=ROWS`,
+              { headers: { Authorization: `Bearer ${accessToken}` } },
+            );
+            if (dataResponse.ok) {
+              data = await dataResponse.json();
+            } else {
+              const fallback = await fetch(
+                `https://sheets.googleapis.com/v4/spreadsheets/${file.id}/values/A:ZZ?majorDimension=ROWS`,
+                { headers: { Authorization: `Bearer ${accessToken}` } },
+              );
+              if (!fallback.ok) {
+                previews.push({ fileId: file.id, fileName: file.name, detectedType: 'error', rowCount: 0, supported: false });
+                continue;
+              }
+              data = await fallback.json();
+            }
+            const rows = data.values || [];
+            if (rows.length < 2) {
+              previews.push({ fileId: file.id, fileName: file.name, detectedType: 'skipped', rowCount: 0, supported: false });
+              continue;
+            }
+            const headers: string[] = rows[0].map((h: string) => h.toLowerCase().trim());
+            const detectedType = detectSheetType(headers);
+            previews.push({
+              fileId: file.id,
+              fileName: file.name,
+              detectedType,
+              rowCount: rows.length - 1,
+              supported: (DRIVE_SUPPORTED_TYPES as readonly string[]).includes(detectedType),
+            });
+          } catch (e: any) {
+            previews.push({ fileId: file.id, fileName: file.name, detectedType: 'error', rowCount: 0, supported: false });
+          }
+        }
+        return { previews };
+      }),
+
     syncGoogleDrive: protectedProcedure
-      .mutation(async ({ ctx }) => {
+      .input(z.object({
+        // When provided, import ONLY these files using the user-confirmed type
+        // (overriding auto-detection). Omitted = legacy "detect & import all".
+        selections: z.array(z.object({
+          fileId: z.string(),
+          type: z.enum(DRIVE_SUPPORTED_TYPES),
+        })).optional(),
+      }).optional())
+      .mutation(async ({ ctx, input }) => {
         const results: { sheet: string; type: string; imported: number; errors: string[] }[] = [];
 
         // 1. Get valid Google OAuth token
@@ -4770,6 +4868,10 @@ ONLY return the JSON array, no other text.`;
         if (tokenError || !accessToken) {
           throw new TRPCError({ code: 'PRECONDITION_FAILED', message: tokenError || 'Google not connected. Go to Settings to connect your Google account.' });
         }
+
+        const forcedTypes = input?.selections && input.selections.length > 0
+          ? new Map(input.selections.map((s) => [s.fileId, s.type as string]))
+          : null;
 
         // 2. List all Google Sheets in Drive
         const sheetsResponse = await fetch(
@@ -4780,7 +4882,9 @@ ONLY return the JSON array, no other text.`;
           throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: 'Failed to list Google Sheets from Drive' });
         }
         const sheetsData = await sheetsResponse.json();
-        const files = sheetsData.files || [];
+        let files = sheetsData.files || [];
+        // Only import the confirmed files when selections were supplied.
+        if (forcedTypes) files = files.filter((f: any) => forcedTypes.has(f.id));
 
         // 3. For each spreadsheet, read the first sheet, detect type, and import
         for (const file of files) {
@@ -4813,21 +4917,10 @@ ONLY return the JSON array, no other text.`;
             const headers: string[] = rows[0].map((h: string) => h.toLowerCase().trim());
             const dataRows: string[][] = rows.slice(1);
 
-            // Auto-detect type based on column headers
-            let type = 'unknown';
-            if (headers.some((h: string) => h.includes('vendor') || h.includes('supplier'))) type = 'vendors';
-            else if (headers.some((h: string) => h.includes('customer') || h.includes('client') || h.includes('buyer'))) type = 'customers';
-            else if (headers.some((h: string) => h.includes('sku') || h.includes('product') || h.includes('item'))) type = 'products';
-            else if (headers.some((h: string) => h.includes('invoice') || h.includes('bill'))) type = 'invoices';
-            else if (headers.some((h: string) => h.includes('employee') || h.includes('team') || h.includes('staff'))) type = 'employees';
-            else if (headers.some((h: string) => h.includes('ingredient') || h.includes('raw material') || h.includes('material'))) type = 'raw_materials';
-            else if (headers.some((h: string) => h.includes('order') || h.includes('po') || h.includes('purchase'))) type = 'purchase_orders';
-            else if (headers.some((h: string) => h.includes('price') || h.includes('cost') || h.includes('rate'))) type = 'products';
-            else if (headers.some((h: string) => h.includes('contact') || h.includes('lead') || h.includes('prospect') || h.includes('pipeline'))) type = 'crm_contacts';
-            else if (headers.some((h: string) => h.includes('investor') || h.includes('fund') || h.includes('commitment') || h.includes('round') || h.includes('series'))) type = 'fundraising';
-            else if (headers.some((h: string) => h.includes('deal') || h.includes('opportunity') || h.includes('stage'))) type = 'crm_deals';
+            // Use the user-confirmed type when supplied, else auto-detect.
+            const type = forcedTypes?.get(file.id) ?? detectSheetType(headers);
 
-            if (type === 'unknown' || type === 'invoices' || type === 'purchase_orders') {
+            if (!(DRIVE_SUPPORTED_TYPES as readonly string[]).includes(type)) {
               results.push({ sheet: file.name, type, imported: 0, errors: type === 'unknown' ? ['Could not detect data type from headers'] : ['Auto-import not supported for this type'] });
               continue;
             }

--- a/server/routers.ts
+++ b/server/routers.ts
@@ -23,6 +23,7 @@ import { autonomousWorkflowRouter } from "./autonomousWorkflowRouter";
 import { agentRouter } from "./agent";
 import { parseNoteWithLLM } from "./notesParser";
 import type { NoteAppliedItem, NoteParseResult, NoteParsedItem } from "@shared/notes";
+import { buildImportRecord } from "@shared/importFields";
 import { employeePortalRouter } from "./routers/employeePortal";
 import { parseCopackerInventoryEmail, applyCopackerInventoryUpdate } from "./copackerEmailExtractor";
 import { parseTextToPO, createPOPreview, createPOFromPreview } from "./textToPOService";
@@ -4643,136 +4644,70 @@ ONLY return the JSON array, no other text.`;
         
         for (const row of data) {
           try {
-            // Map the row data to the target fields
-            const mappedData: Record<string, any> = {};
-            for (const [sheetCol, erpField] of Object.entries(columnMapping)) {
-              if (row[sheetCol] !== undefined && row[sheetCol] !== '') {
-                mappedData[erpField] = row[sheetCol];
-              }
+            // Coerce + validate the row against the destination's field catalogue.
+            // What the UI advertises == what we persist (see shared/importFields.ts).
+            const { record, errors: rowErrors } = buildImportRecord(row, columnMapping, targetModule);
+            if (rowErrors.length > 0) {
+              results.errors.push(rowErrors[0]);
+              results.failed++;
+              continue;
             }
-            
-            // Import based on target module
+
+            // Per-module glue: generated numbers + synthetic/derived columns.
             switch (targetModule) {
               case 'customers':
-                if (!mappedData.name) {
-                  results.errors.push(`Row missing required field: name`);
-                  results.failed++;
-                  continue;
-                }
-                await db.createCustomer({ 
-                  name: mappedData.name,
-                  email: mappedData.email || null,
-                  phone: mappedData.phone || null,
-                  address: mappedData.address || null,
-                  city: mappedData.city || null,
-                  state: mappedData.state || null,
-                  country: mappedData.country || null,
-                  postalCode: mappedData.postalCode || null,
-                  notes: mappedData.notes || null,
-                });
+                await db.createCustomer(record as any);
                 break;
-                
+
               case 'vendors':
-                if (!mappedData.name) {
-                  results.errors.push(`Row missing required field: name`);
-                  results.failed++;
-                  continue;
-                }
-                await db.createVendor({ 
-                  name: mappedData.name,
-                  email: mappedData.email || null,
-                  phone: mappedData.phone || null,
-                  address: mappedData.address || null,
-                  city: mappedData.city || null,
-                  state: mappedData.state || null,
-                  country: mappedData.country || null,
-                  postalCode: mappedData.postalCode || null,
-                  paymentTerms: mappedData.paymentTerms ? parseInt(mappedData.paymentTerms) : null,
-                  notes: mappedData.notes || null,
-                });
+                await db.createVendor(record as any);
                 break;
-                
+
               case 'products':
-                if (!mappedData.name) {
-                  results.errors.push(`Row missing required field: name`);
-                  results.failed++;
-                  continue;
-                }
-                const sku = mappedData.sku || generateNumber('PROD');
-                await db.createProduct({ 
-                  name: mappedData.name,
-                  sku,
-                  unitPrice: mappedData.price || mappedData.unitPrice || '0',
-                  description: mappedData.description || null,
-                  category: mappedData.category || null,
-                  costPrice: mappedData.cost || mappedData.costPrice || null,
-                });
+                await db.createProduct({
+                  ...record,
+                  sku: record.sku || generateNumber('PROD'),
+                  unitPrice: record.unitPrice ?? '0', // NOT NULL on the table
+                } as any);
                 break;
-                
+
               case 'employees':
-                if (!mappedData.firstName || !mappedData.lastName) {
-                  results.errors.push(`Row missing required fields: firstName, lastName`);
-                  results.failed++;
-                  continue;
-                }
-                const employeeNumber = generateNumber('EMP');
-                await db.createEmployee({ 
-                  ...mappedData, 
-                  employeeNumber,
-                  firstName: mappedData.firstName,
-                  lastName: mappedData.lastName,
-                });
+                await db.createEmployee({
+                  ...record,
+                  employeeNumber: generateNumber('EMP'),
+                } as any);
                 break;
-                
-              case 'invoices':
-                if (!mappedData.customerId || !mappedData.amount) {
-                  results.errors.push(`Row missing required fields: customerId, amount`);
-                  results.failed++;
-                  continue;
-                }
-                const invoiceNumber = generateNumber('INV');
-                const amount = mappedData.amount || '0';
-                await db.createInvoice({ 
-                  ...mappedData, 
-                  invoiceNumber,
-                  customerId: parseInt(mappedData.customerId) || 0,
+
+              case 'invoices': {
+                const amount = record.amount ?? '0';
+                delete record.amount; // synthetic -> subtotal/total below
+                await db.createInvoice({
+                  ...record,
+                  invoiceNumber: generateNumber('INV'),
                   issueDate: new Date(),
-                  dueDate: mappedData.dueDate ? new Date(mappedData.dueDate) : new Date(),
+                  dueDate: record.dueDate ?? new Date(),
                   subtotal: amount,
                   totalAmount: amount,
-                });
+                } as any);
                 break;
-                
+              }
+
               case 'contracts':
-                if (!mappedData.title) {
-                  results.errors.push(`Row missing required field: title`);
-                  results.failed++;
-                  continue;
-                }
-                const contractNumber = generateNumber('CON');
-                await db.createContract({ 
-                  ...mappedData, 
-                  contractNumber,
-                  title: mappedData.title,
-                  type: (mappedData.type as any) || 'service',
-                });
+                await db.createContract({
+                  ...record,
+                  contractNumber: generateNumber('CON'),
+                  type: record.type || 'service', // NOT NULL, no default
+                } as any);
                 break;
-                
+
               case 'projects':
-                if (!mappedData.name) {
-                  results.errors.push(`Row missing required field: name`);
-                  results.failed++;
-                  continue;
-                }
-                const projectNumber = generateNumber('PROJ');
-                await db.createProject({ 
-                  ...mappedData, 
-                  projectNumber,
-                  name: mappedData.name,
-                });
+                await db.createProject({
+                  ...record,
+                  projectNumber: generateNumber('PROJ'),
+                } as any);
                 break;
             }
-            
+
             results.imported++;
           } catch (error: any) {
             results.errors.push(`Import error: ${error.message}`);

--- a/server/sheetsImport.test.ts
+++ b/server/sheetsImport.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { appRouter, detectSheetType } from "./routers";
+import * as db from "./db";
 import type { TrpcContext } from "./_core/context";
 
 type AuthenticatedUser = NonNullable<TrpcContext["user"]>;
@@ -223,5 +224,59 @@ describe("Google Sheets Import - Data Import", () => {
 
     expect(result.imported).toBe(1);
     expect(result.failed).toBe(0);
+  });
+
+  it("coerces typed customer fields and persists them", async () => {
+    const caller = appRouter.createCaller(createAdminContext());
+    const result = await caller.sheetsImport.importData({
+      targetModule: "customers",
+      data: [{ Name: "Acme", Kind: "Business", Credit: "$50,000", Terms: "45" }],
+      columnMapping: { Name: "name", Kind: "type", Credit: "creditLimit", Terms: "paymentTerms" },
+    });
+
+    expect(result.imported).toBe(1);
+    expect(db.createCustomer).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "Acme", type: "business", creditLimit: "50000", paymentTerms: 45 }),
+    );
+  });
+
+  it("maps a Job Title column to the jobTitle column (not a dropped key)", async () => {
+    const caller = appRouter.createCaller(createAdminContext());
+    const result = await caller.sheetsImport.importData({
+      targetModule: "employees",
+      data: [{ First: "John", Last: "Doe", "Job Title": "Engineer" }],
+      columnMapping: { First: "firstName", Last: "lastName", "Job Title": "jobTitle" },
+    });
+
+    expect(result.imported).toBe(1);
+    expect(db.createEmployee).toHaveBeenCalledWith(expect.objectContaining({ jobTitle: "Engineer" }));
+  });
+
+  it("derives invoice subtotal/total from amount and coerces customerId", async () => {
+    const caller = appRouter.createCaller(createAdminContext());
+    const result = await caller.sheetsImport.importData({
+      targetModule: "invoices",
+      data: [{ Cust: "7", Total: "$1,250.00" }],
+      columnMapping: { Cust: "customerId", Total: "amount" },
+    });
+
+    expect(result.imported).toBe(1);
+    expect(db.createInvoice).toHaveBeenCalledWith(
+      expect.objectContaining({ customerId: 7, subtotal: "1250.00", totalAmount: "1250.00" }),
+    );
+    // The synthetic `amount` key must not leak onto the invoice insert.
+    expect((db.createInvoice as any).mock.calls[0][0]).not.toHaveProperty("amount");
+  });
+
+  it("rejects a row with an invalid enum value", async () => {
+    const caller = appRouter.createCaller(createAdminContext());
+    const result = await caller.sheetsImport.importData({
+      targetModule: "customers",
+      data: [{ Name: "Acme", Kind: "platinum" }],
+      columnMapping: { Name: "name", Kind: "type" },
+    });
+
+    expect(result.imported).toBe(0);
+    expect(result.failed).toBe(1);
   });
 });

--- a/server/sheetsImport.test.ts
+++ b/server/sheetsImport.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { appRouter } from "./routers";
+import { appRouter, detectSheetType } from "./routers";
 import type { TrpcContext } from "./_core/context";
 
 type AuthenticatedUser = NonNullable<TrpcContext["user"]>;
@@ -43,6 +43,25 @@ function createAdminContext(): TrpcContext {
     } as unknown as TrpcContext["res"],
   };
 }
+
+describe("detectSheetType (Drive auto-sync detection)", () => {
+  // Headers arrive lowercased/trimmed, matching the server read path.
+  it("detects supported types from header keywords", () => {
+    expect(detectSheetType(["vendor name", "email"])).toBe("vendors");
+    expect(detectSheetType(["customer", "phone"])).toBe("customers");
+    expect(detectSheetType(["sku", "price"])).toBe("products");
+    expect(detectSheetType(["first name", "last name", "employee id"])).toBe("employees");
+    expect(detectSheetType(["ingredient", "unit cost"])).toBe("raw_materials");
+    expect(detectSheetType(["contact name", "lead source"])).toBe("crm_contacts");
+    expect(detectSheetType(["investor", "commitment"])).toBe("fundraising");
+  });
+
+  it("returns non-importable markers for ambiguous/unsupported sheets", () => {
+    expect(detectSheetType(["random", "columns"])).toBe("unknown");
+    expect(detectSheetType(["invoice number", "bill to"])).toBe("invoices");
+    expect(detectSheetType(["purchase order", "po number"])).toBe("purchase_orders");
+  });
+});
 
 describe("Google Sheets Import - Data Import", () => {
   beforeEach(() => {

--- a/shared/importFields.ts
+++ b/shared/importFields.ts
@@ -2,11 +2,10 @@
 //
 // This is the single source of truth shared by the Import UI (column-mapping
 // dropdowns + auto-suggestion) and the server `sheetsImport.importData` handler.
-// The `key` values MUST match the field names the server reads off `mappedData`
-// in server/routers.ts (the `importData` mutation). Keeping them here prevents
-// the silent misfiling that happens when a spreadsheet header is naively
-// snake_cased (e.g. "Customer Name" -> "customer_name") and no longer matches
-// the field the server expects ("name").
+// The `key` values MUST match the column names on the destination Drizzle table
+// (see drizzle/schema.ts) so a mapped column actually persists. Keeping the
+// list here — with field types — means "what the UI lets you map" always equals
+// "what the server writes", instead of silently dropping mismatched columns.
 
 export type ImportModule =
   | "customers"
@@ -17,68 +16,135 @@ export type ImportModule =
   | "contracts"
   | "projects";
 
+export type ImportFieldType = "string" | "int" | "decimal" | "date" | "boolean" | "enum";
+
 export type ImportFieldDef = {
-  /** Canonical ERP field name the server consumes. */
+  /** Canonical column name on the destination table (or a synthetic key the
+   *  server maps explicitly, e.g. invoices `amount`). */
   key: string;
   /** Human-readable label shown in the mapping UI. */
   label: string;
   /** Whether a row is rejected when this field is unmapped/empty. */
   required?: boolean;
+  /** Value type, used for server-side coercion. Defaults to "string". */
+  type?: ImportFieldType;
+  /** Allowed values for `type: "enum"` (case-insensitive match). */
+  enumValues?: readonly string[];
   /** Lowercased header fragments used to auto-suggest a mapping. */
   aliases?: string[];
 };
+
+const ADDRESS_FIELDS: ImportFieldDef[] = [
+  { key: "address", label: "Address", aliases: ["street", "address line 1", "address1"] },
+  { key: "city", label: "City", aliases: ["town"] },
+  { key: "state", label: "State", aliases: ["province", "region"] },
+  { key: "country", label: "Country" },
+  { key: "postalCode", label: "Postal code", aliases: ["zip", "zip code", "postcode", "postal"] },
+];
 
 export const IMPORT_FIELDS: Record<ImportModule, ImportFieldDef[]> = {
   customers: [
     { key: "name", label: "Name", required: true, aliases: ["customer", "customer name", "company", "client", "account"] },
     { key: "email", label: "Email", aliases: ["e-mail", "email address"] },
     { key: "phone", label: "Phone", aliases: ["telephone", "mobile", "cell", "phone number"] },
-    { key: "address", label: "Address", aliases: ["street", "address line 1", "address1"] },
-    { key: "city", label: "City", aliases: ["town"] },
-    { key: "state", label: "State", aliases: ["province", "region"] },
-    { key: "country", label: "Country" },
-    { key: "postalCode", label: "Postal code", aliases: ["zip", "zip code", "postcode", "postal"] },
+    ...ADDRESS_FIELDS,
+    { key: "type", label: "Type", type: "enum", enumValues: ["individual", "business"] },
+    { key: "status", label: "Status", type: "enum", enumValues: ["active", "inactive", "prospect"] },
+    { key: "creditLimit", label: "Credit limit", type: "decimal", aliases: ["credit"] },
+    { key: "paymentTerms", label: "Payment terms (days)", type: "int", aliases: ["terms", "net", "payment term"] },
     { key: "notes", label: "Notes", aliases: ["note", "comment", "comments"] },
   ],
   vendors: [
     { key: "name", label: "Name", required: true, aliases: ["vendor", "vendor name", "supplier", "company"] },
+    { key: "contactName", label: "Contact name", aliases: ["contact", "primary contact", "attention"] },
     { key: "email", label: "Email", aliases: ["e-mail", "email address"] },
     { key: "phone", label: "Phone", aliases: ["telephone", "mobile", "phone number"] },
-    { key: "address", label: "Address", aliases: ["street", "address line 1", "address1"] },
-    { key: "city", label: "City", aliases: ["town"] },
-    { key: "state", label: "State", aliases: ["province", "region"] },
-    { key: "country", label: "Country" },
-    { key: "postalCode", label: "Postal code", aliases: ["zip", "zip code", "postcode", "postal"] },
-    { key: "paymentTerms", label: "Payment terms (days)", aliases: ["terms", "net", "payment term"] },
+    ...ADDRESS_FIELDS,
+    { key: "type", label: "Type", type: "enum", enumValues: ["supplier", "contractor", "service"] },
+    { key: "status", label: "Status", type: "enum", enumValues: ["active", "inactive", "pending"] },
+    { key: "paymentTerms", label: "Payment terms (days)", type: "int", aliases: ["terms", "net", "payment term"] },
+    { key: "taxId", label: "Tax ID", aliases: ["tax id", "ein", "vat", "vat number"] },
+    { key: "bankAccount", label: "Bank account", aliases: ["account number", "bank acct"] },
+    { key: "bankRouting", label: "Bank routing", aliases: ["routing", "routing number", "aba"] },
+    { key: "defaultLeadTimeDays", label: "Lead time (days)", type: "int", aliases: ["lead time", "lead time days"] },
+    { key: "minOrderAmount", label: "Min order amount", type: "decimal", aliases: ["minimum order", "moq amount"] },
+    { key: "shippingMethod", label: "Shipping method", aliases: ["ship method", "shipping"] },
     { key: "notes", label: "Notes", aliases: ["note", "comment", "comments"] },
   ],
   products: [
     { key: "name", label: "Name", required: true, aliases: ["product", "product name", "item", "item name", "title"] },
     { key: "sku", label: "SKU", aliases: ["item code", "product code", "code", "part number", "part no"] },
-    { key: "unitPrice", label: "Unit price", aliases: ["price", "sell price", "sale price", "list price", "unit cost"] },
     { key: "description", label: "Description", aliases: ["desc", "details"] },
-    { key: "category", label: "Category", aliases: ["type", "group"] },
-    { key: "costPrice", label: "Cost price", aliases: ["cost", "buy price", "purchase price"] },
+    { key: "category", label: "Category", aliases: ["group", "grouping"] },
+    { key: "type", label: "Type", type: "enum", enumValues: ["physical", "digital", "service"] },
+    { key: "manufacturingStage", label: "Manufacturing stage", type: "enum", enumValues: ["raw_material", "semi_finished_good", "finished_product"], aliases: ["stage", "mfg stage"] },
+    { key: "unitPrice", label: "Unit price", type: "decimal", aliases: ["price", "sell price", "sale price", "list price"] },
+    { key: "costPrice", label: "Cost price", type: "decimal", aliases: ["cost", "buy price", "purchase price"] },
+    { key: "currency", label: "Currency", aliases: ["ccy"] },
+    { key: "taxable", label: "Taxable", type: "boolean", aliases: ["is taxable"] },
+    { key: "taxRate", label: "Tax rate", type: "decimal", aliases: ["tax", "vat rate"] },
+    { key: "status", label: "Status", type: "enum", enumValues: ["active", "inactive", "discontinued"] },
   ],
   employees: [
     { key: "firstName", label: "First name", required: true, aliases: ["first name", "given name", "forename"] },
     { key: "lastName", label: "Last name", required: true, aliases: ["last name", "surname", "family name"] },
-    { key: "email", label: "Email", aliases: ["e-mail", "work email", "email address"] },
+    { key: "email", label: "Work email", aliases: ["e-mail", "work email", "email address"] },
+    { key: "personalEmail", label: "Personal email", aliases: ["personal email", "home email"] },
     { key: "phone", label: "Phone", aliases: ["telephone", "mobile", "phone number"] },
-    { key: "title", label: "Job title", aliases: ["role", "position", "job"] },
-    { key: "department", label: "Department", aliases: ["dept", "team"] },
+    ...ADDRESS_FIELDS,
+    { key: "jobTitle", label: "Job title", aliases: ["title", "job title", "role", "position", "job"] },
+    { key: "dateOfBirth", label: "Date of birth", type: "date", aliases: ["dob", "birth date", "birthday"] },
+    { key: "hireDate", label: "Hire date", type: "date", aliases: ["hire date", "start date", "joined"] },
+    { key: "terminationDate", label: "Termination date", type: "date", aliases: ["term date", "end date", "left"] },
+    { key: "employmentType", label: "Employment type", type: "enum", enumValues: ["full_time", "part_time", "contractor", "intern"], aliases: ["employment", "worker type"] },
+    { key: "status", label: "Status", type: "enum", enumValues: ["active", "inactive", "on_leave", "terminated"] },
+    { key: "salary", label: "Salary", type: "decimal", aliases: ["pay", "compensation", "comp"] },
+    { key: "salaryFrequency", label: "Salary frequency", type: "enum", enumValues: ["hourly", "weekly", "biweekly", "monthly", "annual"], aliases: ["pay frequency", "frequency"] },
+    { key: "currency", label: "Currency", aliases: ["ccy"] },
+    { key: "bankAccount", label: "Bank account", aliases: ["account number", "bank acct"] },
+    { key: "bankRouting", label: "Bank routing", aliases: ["routing", "routing number", "aba"] },
+    { key: "taxId", label: "Tax ID / SSN", aliases: ["ssn", "tax id", "national id"] },
+    { key: "notes", label: "Notes", aliases: ["note", "comment", "comments"] },
   ],
   invoices: [
-    { key: "customerId", label: "Customer ID", required: true, aliases: ["customer id", "customerid", "customer", "client id"] },
-    { key: "amount", label: "Amount", required: true, aliases: ["total", "total amount", "invoice amount", "value"] },
-    { key: "dueDate", label: "Due date", aliases: ["due", "due date", "payment due"] },
+    { key: "customerId", label: "Customer ID", required: true, type: "int", aliases: ["customer id", "customerid", "customer", "client id"] },
+    { key: "amount", label: "Amount", required: true, type: "decimal", aliases: ["total", "total amount", "invoice amount", "value"] },
+    { key: "type", label: "Type", type: "enum", enumValues: ["invoice", "credit_note", "quote"] },
+    { key: "status", label: "Status", type: "enum", enumValues: ["draft", "sent", "paid", "partial", "overdue", "cancelled"] },
+    { key: "dueDate", label: "Due date", type: "date", aliases: ["due", "due date", "payment due"] },
+    { key: "taxAmount", label: "Tax amount", type: "decimal", aliases: ["tax", "vat"] },
+    { key: "discountAmount", label: "Discount amount", type: "decimal", aliases: ["discount"] },
+    { key: "currency", label: "Currency", aliases: ["ccy"] },
+    { key: "notes", label: "Notes", aliases: ["note", "memo"] },
+    { key: "terms", label: "Terms", aliases: ["payment terms"] },
   ],
   contracts: [
     { key: "title", label: "Title", required: true, aliases: ["name", "contract", "contract name", "agreement"] },
-    { key: "type", label: "Type", aliases: ["category", "contract type"] },
+    { key: "type", label: "Type", type: "enum", enumValues: ["customer", "vendor", "employment", "nda", "partnership", "lease", "service", "other"] },
+    { key: "status", label: "Status", type: "enum", enumValues: ["draft", "pending_review", "pending_signature", "active", "expired", "terminated", "renewed"] },
+    { key: "partyName", label: "Party name", aliases: ["party", "counterparty", "company"] },
+    { key: "partyType", label: "Party type", type: "enum", enumValues: ["customer", "vendor", "employee", "other"] },
+    { key: "startDate", label: "Start date", type: "date", aliases: ["start", "effective date", "start date"] },
+    { key: "endDate", label: "End date", type: "date", aliases: ["end", "expiry", "expiration", "end date"] },
+    { key: "renewalDate", label: "Renewal date", type: "date", aliases: ["renewal", "renew date"] },
+    { key: "value", label: "Value", type: "decimal", aliases: ["amount", "contract value"] },
+    { key: "currency", label: "Currency", aliases: ["ccy"] },
+    { key: "description", label: "Description", aliases: ["desc", "details"] },
+    { key: "terms", label: "Terms", aliases: ["payment terms"] },
   ],
   projects: [
     { key: "name", label: "Name", required: true, aliases: ["project", "project name", "title"] },
+    { key: "description", label: "Description", aliases: ["desc", "details"] },
+    { key: "type", label: "Type", type: "enum", enumValues: ["internal", "client", "product", "research", "other"] },
+    { key: "status", label: "Status", type: "enum", enumValues: ["planning", "active", "on_hold", "completed", "cancelled"] },
+    { key: "priority", label: "Priority", type: "enum", enumValues: ["low", "medium", "high", "critical"] },
+    { key: "startDate", label: "Start date", type: "date", aliases: ["start", "start date", "kickoff"] },
+    { key: "targetEndDate", label: "Target end date", type: "date", aliases: ["end date", "target date", "deadline", "due"] },
+    { key: "budget", label: "Budget", type: "decimal", aliases: ["budgeted"] },
+    { key: "actualCost", label: "Actual cost", type: "decimal", aliases: ["cost", "spent"] },
+    { key: "currency", label: "Currency", aliases: ["ccy"] },
+    { key: "progress", label: "Progress (%)", type: "int", aliases: ["percent complete", "completion"] },
+    { key: "notes", label: "Notes", aliases: ["note", "comment", "comments"] },
   ],
 };
 
@@ -154,4 +220,66 @@ export function buildDefaultMapping(headers: string[], module: ImportModule): Re
 export function missingRequiredFields(module: ImportModule, mapping: Record<string, string>): ImportFieldDef[] {
   const mapped = new Set(Object.values(mapping));
   return IMPORT_FIELDS[module].filter((f) => f.required && !mapped.has(f.key));
+}
+
+/** Coerce a raw spreadsheet string into the typed value its field expects. */
+export function coerceImportValue(raw: string, def: ImportFieldDef): { value?: any; error?: string } {
+  const v = (raw ?? "").trim();
+  if (v === "") return { value: undefined };
+  switch (def.type) {
+    case "int": {
+      const n = parseInt(v.replace(/[,\s]/g, ""), 10);
+      return Number.isNaN(n) ? { error: `"${def.label}" must be a whole number (got "${raw}")` } : { value: n };
+    }
+    case "decimal": {
+      const cleaned = v.replace(/[$,\s]/g, "");
+      return Number.isNaN(Number(cleaned)) ? { error: `"${def.label}" must be a number (got "${raw}")` } : { value: cleaned };
+    }
+    case "date": {
+      const d = new Date(v);
+      return Number.isNaN(d.getTime()) ? { error: `"${def.label}" is not a valid date (got "${raw}")` } : { value: d };
+    }
+    case "boolean":
+      return { value: /^(1|true|yes|y|t)$/i.test(v) };
+    case "enum": {
+      const match = def.enumValues?.find((e) => normalize(e) === normalize(v));
+      return match ? { value: match } : { error: `"${def.label}" must be one of: ${def.enumValues?.join(", ")} (got "${raw}")` };
+    }
+    default:
+      return { value: v };
+  }
+}
+
+/**
+ * Turn one raw spreadsheet row + column mapping into a typed record ready for
+ * the destination table's insert, plus any per-row validation errors. Only
+ * fields the user mapped are written; required fields are enforced here.
+ */
+export function buildImportRecord(
+  row: Record<string, string>,
+  columnMapping: Record<string, string>,
+  module: ImportModule,
+): { record: Record<string, any>; errors: string[] } {
+  const byKey = new Map(IMPORT_FIELDS[module].map((d) => [d.key, d]));
+  const record: Record<string, any> = {};
+  const errors: string[] = [];
+
+  for (const [column, fieldKey] of Object.entries(columnMapping)) {
+    if (!fieldKey) continue;
+    const def = byKey.get(fieldKey);
+    if (!def) continue;
+    const raw = row[column];
+    if (raw === undefined) continue;
+    const { value, error } = coerceImportValue(String(raw), def);
+    if (error) errors.push(error);
+    else if (value !== undefined) record[fieldKey] = value;
+  }
+
+  for (const def of IMPORT_FIELDS[module]) {
+    if (def.required && (record[def.key] === undefined || record[def.key] === "")) {
+      errors.push(`Missing required field: ${def.label}`);
+    }
+  }
+
+  return { record, errors };
 }

--- a/shared/importFields.ts
+++ b/shared/importFields.ts
@@ -85,6 +85,22 @@ export const IMPORT_FIELDS: Record<ImportModule, ImportFieldDef[]> = {
 /** Sentinel value meaning "do not import this column". */
 export const IMPORT_SKIP = "";
 
+/**
+ * Destination types the Google Drive auto-sync importer can write to. MUST stay
+ * in sync with `DRIVE_SUPPORTED_TYPES` in server/routers.ts — these are the
+ * options offered when a user confirms/overrides a detected sheet type.
+ */
+export const DRIVE_IMPORT_TYPES = [
+  { value: "vendors", label: "Vendors" },
+  { value: "customers", label: "Customers" },
+  { value: "products", label: "Products" },
+  { value: "employees", label: "Employees" },
+  { value: "raw_materials", label: "Raw materials" },
+  { value: "crm_contacts", label: "CRM contacts" },
+  { value: "crm_deals", label: "CRM deals" },
+  { value: "fundraising", label: "Fundraising / investors" },
+] as const;
+
 function normalize(s: string): string {
   return s.toLowerCase().replace(/[\s_-]+/g, " ").trim();
 }

--- a/shared/importFields.ts
+++ b/shared/importFields.ts
@@ -1,0 +1,141 @@
+// Canonical catalogue of the fields each import target accepts.
+//
+// This is the single source of truth shared by the Import UI (column-mapping
+// dropdowns + auto-suggestion) and the server `sheetsImport.importData` handler.
+// The `key` values MUST match the field names the server reads off `mappedData`
+// in server/routers.ts (the `importData` mutation). Keeping them here prevents
+// the silent misfiling that happens when a spreadsheet header is naively
+// snake_cased (e.g. "Customer Name" -> "customer_name") and no longer matches
+// the field the server expects ("name").
+
+export type ImportModule =
+  | "customers"
+  | "vendors"
+  | "products"
+  | "invoices"
+  | "employees"
+  | "contracts"
+  | "projects";
+
+export type ImportFieldDef = {
+  /** Canonical ERP field name the server consumes. */
+  key: string;
+  /** Human-readable label shown in the mapping UI. */
+  label: string;
+  /** Whether a row is rejected when this field is unmapped/empty. */
+  required?: boolean;
+  /** Lowercased header fragments used to auto-suggest a mapping. */
+  aliases?: string[];
+};
+
+export const IMPORT_FIELDS: Record<ImportModule, ImportFieldDef[]> = {
+  customers: [
+    { key: "name", label: "Name", required: true, aliases: ["customer", "customer name", "company", "client", "account"] },
+    { key: "email", label: "Email", aliases: ["e-mail", "email address"] },
+    { key: "phone", label: "Phone", aliases: ["telephone", "mobile", "cell", "phone number"] },
+    { key: "address", label: "Address", aliases: ["street", "address line 1", "address1"] },
+    { key: "city", label: "City", aliases: ["town"] },
+    { key: "state", label: "State", aliases: ["province", "region"] },
+    { key: "country", label: "Country" },
+    { key: "postalCode", label: "Postal code", aliases: ["zip", "zip code", "postcode", "postal"] },
+    { key: "notes", label: "Notes", aliases: ["note", "comment", "comments"] },
+  ],
+  vendors: [
+    { key: "name", label: "Name", required: true, aliases: ["vendor", "vendor name", "supplier", "company"] },
+    { key: "email", label: "Email", aliases: ["e-mail", "email address"] },
+    { key: "phone", label: "Phone", aliases: ["telephone", "mobile", "phone number"] },
+    { key: "address", label: "Address", aliases: ["street", "address line 1", "address1"] },
+    { key: "city", label: "City", aliases: ["town"] },
+    { key: "state", label: "State", aliases: ["province", "region"] },
+    { key: "country", label: "Country" },
+    { key: "postalCode", label: "Postal code", aliases: ["zip", "zip code", "postcode", "postal"] },
+    { key: "paymentTerms", label: "Payment terms (days)", aliases: ["terms", "net", "payment term"] },
+    { key: "notes", label: "Notes", aliases: ["note", "comment", "comments"] },
+  ],
+  products: [
+    { key: "name", label: "Name", required: true, aliases: ["product", "product name", "item", "item name", "title"] },
+    { key: "sku", label: "SKU", aliases: ["item code", "product code", "code", "part number", "part no"] },
+    { key: "unitPrice", label: "Unit price", aliases: ["price", "sell price", "sale price", "list price", "unit cost"] },
+    { key: "description", label: "Description", aliases: ["desc", "details"] },
+    { key: "category", label: "Category", aliases: ["type", "group"] },
+    { key: "costPrice", label: "Cost price", aliases: ["cost", "buy price", "purchase price"] },
+  ],
+  employees: [
+    { key: "firstName", label: "First name", required: true, aliases: ["first name", "given name", "forename"] },
+    { key: "lastName", label: "Last name", required: true, aliases: ["last name", "surname", "family name"] },
+    { key: "email", label: "Email", aliases: ["e-mail", "work email", "email address"] },
+    { key: "phone", label: "Phone", aliases: ["telephone", "mobile", "phone number"] },
+    { key: "title", label: "Job title", aliases: ["role", "position", "job"] },
+    { key: "department", label: "Department", aliases: ["dept", "team"] },
+  ],
+  invoices: [
+    { key: "customerId", label: "Customer ID", required: true, aliases: ["customer id", "customerid", "customer", "client id"] },
+    { key: "amount", label: "Amount", required: true, aliases: ["total", "total amount", "invoice amount", "value"] },
+    { key: "dueDate", label: "Due date", aliases: ["due", "due date", "payment due"] },
+  ],
+  contracts: [
+    { key: "title", label: "Title", required: true, aliases: ["name", "contract", "contract name", "agreement"] },
+    { key: "type", label: "Type", aliases: ["category", "contract type"] },
+  ],
+  projects: [
+    { key: "name", label: "Name", required: true, aliases: ["project", "project name", "title"] },
+  ],
+};
+
+/** Sentinel value meaning "do not import this column". */
+export const IMPORT_SKIP = "";
+
+function normalize(s: string): string {
+  return s.toLowerCase().replace(/[\s_-]+/g, " ").trim();
+}
+
+/**
+ * Suggest the best canonical field for a spreadsheet header. Returns the field
+ * `key`, or `IMPORT_SKIP` ("") when nothing matches confidently.
+ */
+export function suggestFieldForHeader(header: string, module: ImportModule): string {
+  const h = normalize(header);
+  if (!h) return IMPORT_SKIP;
+  const fields = IMPORT_FIELDS[module];
+
+  // 1. Exact match on the canonical key (space/underscore-insensitive).
+  for (const f of fields) {
+    if (normalize(f.key) === h) return f.key;
+  }
+  // 2. Exact match on a declared alias or the label.
+  for (const f of fields) {
+    if (normalize(f.label) === h) return f.key;
+    if (f.aliases?.some((a) => normalize(a) === h)) return f.key;
+  }
+  // 3. Substring match against key / label / aliases (header contains term or vice versa).
+  for (const f of fields) {
+    const terms = [f.key, f.label, ...(f.aliases ?? [])].map(normalize);
+    if (terms.some((t) => t.length >= 3 && (h.includes(t) || t.includes(h)))) return f.key;
+  }
+  return IMPORT_SKIP;
+}
+
+/**
+ * Build a default header -> field mapping for a freshly-parsed file. Avoids
+ * mapping two headers to the same field (first match wins).
+ */
+export function buildDefaultMapping(headers: string[], module: ImportModule): Record<string, string> {
+  const mapping: Record<string, string> = {};
+  const used = new Set<string>();
+  for (const header of headers) {
+    const suggestion = suggestFieldForHeader(header, module);
+    if (suggestion && !used.has(suggestion)) {
+      mapping[header] = suggestion;
+      used.add(suggestion);
+    } else {
+      mapping[header] = IMPORT_SKIP;
+    }
+  }
+  return mapping;
+}
+
+/** Required field keys for a module that are not covered by the mapping. */
+export function missingRequiredFields(module: ImportModule, mapping: Record<string, string>): ImportFieldDef[] {
+  const mapped = new Set(Object.values(mapping));
+  return IMPORT_FIELDS[module].filter((f) => f.required && !mapped.has(f.key));
+}

--- a/test-pat.txt
+++ b/test-pat.txt
@@ -1,1 +1,0 @@
-test pat write


### PR DESCRIPTION
## Summary

Improvements to the **Import** page (`/import`) plus two CI/repair fixes.

### 1. File name search
"Search files by name..." on both the Drive sync selector and the Drive file browser.

### 2. Confirm-before-import (right *table* and right *field*)
- **Manual upload** — explicit column → field mapping UI driven by `shared/importFields.ts` (single source of truth matching the DB columns), pre-filled by alias matching; required fields enforced.
- **Drive auto-sync** — `previewGoogleDrive` returns the detected type per sheet without writing; a confirmation panel lets you override the destination per file before `syncGoogleDrive` imports only the confirmed selections.

### 3. Data-fidelity: all important info gets parsed & persisted
A field-coverage audit found data being silently dropped. Fixed:
- **RFC 4180 CSV + multi-sheet** — replaced the naive comma/tab splitter with SheetJS for CSV and XLSX, so quoted commas / escaped quotes / embedded newlines no longer mis-align columns; every sheet is read (with a sheet picker) instead of only the first tab.
- **Pre-flight transparency** — the panel shows how many columns will be written vs ignored, and warns on multi-sheet workbooks.
- **Widen + reconcile fields** — the catalogue now carries field *types* and covers the real business columns on each table (status, type, dates, financial/banking, payment terms, etc.), with keys matching `drizzle/schema.ts`. `importData` builds the insert from the catalogue with `coerceImportValue` (numbers strip `$`/commas, dates parsed, enums validated) instead of a blind spread — so what the UI lets you map is exactly what gets written. Fixes silent drops like a "Job Title" column never reaching the `jobTitle` DB column.

### 4. Repair corrupted files merged via PR #284
`RdTaxCredit.tsx` (mojibake + scrambled `ImportFromQBButton`/`InlineRdPercent`) and `ShopifySettings.tsx` (jammed import, broken `createMapping`, deleted closing tags) failed Type Check / Build on every branch off `main`. Repaired; removed stray `test-pat.txt`.

### 5. Fix Strict Ratchet false failure on fresh checkouts
`scripts/strict-ratchet.mjs` aborted on `tsc` exit code `2` (which `incremental: true` produces on a fresh checkout when diagnostics are present). Exit `2` is now treated as a completed typecheck; codes `>= 3` remain fatal.

## Testing

- `pnpm check` / `pnpm check:strict` / `pnpm build` — pass
- `pnpm strict:check` (fresh, no `.tsbuildinfo`) — passes (141 ≤ baseline 142)
- `pnpm test` — 887/887 pass, including new tests for column-mapping suggestion, type coercion, enum rejection, the jobTitle fix, invoice subtotal/total derivation, and Drive `detectSheetType`

## Known follow-ups (not in this PR)
- Drive auto-sync still reads a hardcoded per-type field subset (fewer fields than manual upload) and supports raw_materials/CRM/fundraising but not invoices/contracts/projects — unifying it with the shared catalogue is a sensible next step.

https://claude.ai/code/session_01ABy1b8ESRUA7juHVpQgGVA

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABy1b8ESRUA7juHVpQgGVA)_