### PR TITLE
Fix build-breaking syntax corruption in RdTaxCredit and ShopifySettings

### DIFF
--- a/client/src/pages/finance/RdTaxCredit.tsx
+++ b/client/src/pages/finance/RdTaxCredit.tsx
@@ -73,7 +73,7 @@ export default function RdTaxCredit() {
           <h1 className="text-2xl font-bold flex items-center gap-2">
             <FlaskConical className="h-6 w-6" /> R&D Tax Credit
           </h1>
-          <p className="text-muted-foreground">IRC Section 41 â Calculate and file R&D tax credits (Form 6765)</p>
+          <p className="text-muted-foreground">IRC Section 41 — Calculate and file R&D tax credits (Form 6765)</p>
         </div>
         <Button onClick={() => setShowNewStudy(true)}>
           <Plus className="h-4 w-4 mr-2" /> New Study
@@ -119,7 +119,7 @@ function StudyList({ onSelect }: { onSelect: (id: number) => void }) {
                   <Badge className={statusColors[study.status] || ""}>{study.status.replace("_", " ")}</Badge>
                   <Badge variant="outline">{study.calculationMethod === "asc" ? "ASC Method" : "Regular Credit"}</Badge>
                 </div>
-                <p className="text-sm text-muted-foreground">Tax Year {study.taxYear} â Form {study.formNumber || "6765"}</p>
+                <p className="text-sm text-muted-foreground">Tax Year {study.taxYear} — Form {study.formNumber || "6765"}</p>
               </div>
               <div className="text-right space-y-1">
                 <p className="text-2xl font-bold text-green-600">{fmt(study.netCredit)}</p>
@@ -184,8 +184,8 @@ function NewStudyDialog({ open, onOpenChange }: { open: boolean; onOpenChange: (
             <Select value={form.calculationMethod} onValueChange={(v) => setForm(f => ({ ...f, calculationMethod: v as any }))}>
               <SelectTrigger><SelectValue /></SelectTrigger>
               <SelectContent>
-                <SelectItem value="asc">Alternative Simplified Credit (ASC) â 14% rate</SelectItem>
-                <SelectItem value="regular">Regular Credit (RC) â 20% rate</SelectItem>
+                <SelectItem value="asc">Alternative Simplified Credit (ASC) — 14% rate</SelectItem>
+                <SelectItem value="regular">Regular Credit (RC) — 20% rate</SelectItem>
               </SelectContent>
             </Select>
           </div>
@@ -263,7 +263,7 @@ function StudyDetail({ studyId, onBack }: { studyId: number; onBack: () => void 
           <Button variant="ghost" size="sm" onClick={onBack}><ArrowLeft className="h-4 w-4" /></Button>
           <div>
             <h1 className="text-2xl font-bold">{study.studyName}</h1>
-            <p className="text-muted-foreground">Tax Year {study.taxYear} â {study.calculationMethod === "asc" ? "Alternative Simplified Credit" : "Regular Credit"}</p>
+            <p className="text-muted-foreground">Tax Year {study.taxYear} — {study.calculationMethod === "asc" ? "Alternative Simplified Credit" : "Regular Credit"}</p>
           </div>
           <Badge className={statusColors[study.status] || ""}>{study.status.replace("_", " ")}</Badge>
         </div>
@@ -280,7 +280,7 @@ function StudyDetail({ studyId, onBack }: { studyId: number; onBack: () => void 
           </Select>
           <div className="flex items-center gap-2 text-sm">
             <Switch id="elect280c" checked={elect280C} onCheckedChange={setElect280C} />
-            <Label htmlFor="elect280c" className="cursor-pointer whitespace-nowrap">Â§280C Election</Label>
+            <Label htmlFor="elect280c" className="cursor-pointer whitespace-nowrap">§280C Election</Label>
           </div>
           <Button onClick={() => calculateCredit.mutate({ studyId, elect280CReduction: elect280C })} disabled={calculateCredit.isPending}>
             {calculateCredit.isPending ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : <Calculator className="h-4 w-4 mr-2" />}
@@ -307,7 +307,7 @@ function StudyDetail({ studyId, onBack }: { studyId: number; onBack: () => void 
           <p className="text-xl font-bold">{fmt(study.grossCredit)}</p>
         </CardContent></Card>
         <Card><CardContent className="pt-4 text-center">
-          <p className="text-xs text-muted-foreground">Â§280C Reduction</p>
+          <p className="text-xs text-muted-foreground">§280C Reduction</p>
           <p className="text-xl font-bold text-red-500">{fmt(study.section280CReduction)}</p>
         </CardContent></Card>
         <Card className="border-green-200 bg-green-50"><CardContent className="pt-4 text-center">
@@ -457,7 +457,7 @@ function ProjectsTab({ studyId, projects, onRefresh }: { studyId: number; projec
         <DialogContent className="max-w-2xl max-h-[80vh] overflow-y-auto">
           <DialogHeader>
             <DialogTitle>Add R&D Project</DialogTitle>
-            <DialogDescription>Document the project and complete the IRC Â§41 four-part test.</DialogDescription>
+            <DialogDescription>Document the project and complete the IRC §41 four-part test.</DialogDescription>
           </DialogHeader>
           <div className="space-y-4">
             <div className="grid grid-cols-2 gap-4">
@@ -468,7 +468,7 @@ function ProjectsTab({ studyId, projects, onRefresh }: { studyId: number; projec
 
             {/* Four-Part Test */}
             <div className="border rounded-lg p-4 space-y-4">
-              <h4 className="font-semibold flex items-center gap-2"><ClipboardCheck className="h-4 w-4" /> IRC Â§41 Four-Part Test</h4>
+              <h4 className="font-semibold flex items-center gap-2"><ClipboardCheck className="h-4 w-4" /> IRC §41 Four-Part Test</h4>
 
               {[
                 { key: "technologicalInNature", notesKey: "technologicalNatureNotes", label: "1. Technological in Nature", desc: "Does the activity rely on principles of physical/biological science, engineering, or computer science?" },
@@ -501,7 +501,7 @@ function ProjectsTab({ studyId, projects, onRefresh }: { studyId: number; projec
 
               <div className="border-t pt-3">
                 {fourPartTestPasses(form) ? (
-                  <Badge className="bg-green-100 text-green-700"><CheckCircle2 className="h-3 w-3 mr-1" /> All four parts satisfied â project qualifies</Badge>
+                  <Badge className="bg-green-100 text-green-700"><CheckCircle2 className="h-3 w-3 mr-1" /> All four parts satisfied — project qualifies</Badge>
                 ) : (
                   <Badge className="bg-yellow-100 text-yellow-700">Complete all four parts for the project to qualify</Badge>
                 )}
@@ -584,8 +584,10 @@ function ExpensesTab({ studyId, projects, expenses, onRefresh }: { studyId: numb
             <span>Contract: <strong>{fmt(contractTotal)}</strong></span>
           </div>
         </div>
-        <Button size="sm" onClick={() => setShowNew(true)}><Plus className="h-4 w-4 mr-1" /> Add Expense</Button>
-                <ImportFromQBButton studyId={studyId} projects={projects} onRefresh={onRefresh} />
+        <div className="flex gap-2">
+          <ImportFromQBButton studyId={studyId} projects={projects} onRefresh={onRefresh} />
+          <Button size="sm" onClick={() => setShowNew(true)}><Plus className="h-4 w-4 mr-1" /> Add Expense</Button>
+        </div>
       </div>
 
       {expenses.length === 0 ? (
@@ -607,8 +609,8 @@ function ExpensesTab({ studyId, projects, expenses, onRefresh }: { studyId: numb
             {expenses.map((exp) => (
               <TableRow key={exp.id}>
                 <TableCell><Badge variant="outline">{categoryLabels[exp.category] || exp.category}</Badge></TableCell>
-                <TableCell className="max-w-xs truncate">{exp.description || "â"}</TableCell>
-                <TableCell>{exp.employeeName || exp.vendorName || "â"}</TableCell>
+                <TableCell className="max-w-xs truncate">{exp.description || "—"}</TableCell>
+                <TableCell>{exp.employeeName || exp.vendorName || "—"}</TableCell>
                 <TableCell className="text-right">{fmt(exp.grossAmount)}</TableCell>
                 <TableCell className="text-right">
                   <InlineRdPercent
@@ -642,7 +644,7 @@ function ExpensesTab({ studyId, projects, expenses, onRefresh }: { studyId: numb
                 <Select value={form.projectId} onValueChange={v => setForm(f => ({ ...f, projectId: v }))}>
                   <SelectTrigger><SelectValue placeholder="Select project" /></SelectTrigger>
                   <SelectContent>
-                    {projects.map((p) => <SelectItem key={p.id ?? 0} value={String(p.id ?? 0)}>{p.projectName ?? ''}</SelectItem>)}
+                    {projects.map((p) => <SelectItem key={p.id} value={String(p.id)}>{p.projectName}</SelectItem>)}
                   </SelectContent>
                 </Select>
               </div>
@@ -672,7 +674,7 @@ function ExpensesTab({ studyId, projects, expenses, onRefresh }: { studyId: numb
               <div><Label>Qualified Amount</Label><Input value={computeQualified()} readOnly className="bg-muted" /></div>
             </div>
             {form.category === "contract_research" && (
-              <p className="text-xs text-muted-foreground">Contract research expenses are qualified at 65% per IRC Â§41(b)(3).</p>
+              <p className="text-xs text-muted-foreground">Contract research expenses are qualified at 65% per IRC §41(b)(3).</p>
             )}
           </div>
           <DialogFooter>
@@ -715,18 +717,18 @@ function Form6765Tab({ studyId }: { studyId: number }) {
     <div className="space-y-6">
       <Card>
         <CardHeader>
-          <CardTitle className="flex items-center gap-2"><FileText className="h-5 w-5" /> IRS Form 6765 â Credit for Increasing Research Activities</CardTitle>
-          <CardDescription>Tax Year {form.taxYear} â {form.calculationMethod === "asc" ? "Section B (Alternative Simplified Credit)" : "Section A (Regular Credit)"}</CardDescription>
+          <CardTitle className="flex items-center gap-2"><FileText className="h-5 w-5" /> IRS Form 6765 — Credit for Increasing Research Activities</CardTitle>
+          <CardDescription>Tax Year {form.taxYear} — {form.calculationMethod === "asc" ? "Section B (Alternative Simplified Credit)" : "Section A (Regular Credit)"}</CardDescription>
         </CardHeader>
         <CardContent className="space-y-6">
           {/* QRE Summary */}
           <div className="border rounded-lg p-4 space-y-3">
             <h4 className="font-semibold">Qualified Research Expenses</h4>
             <div className="grid grid-cols-2 gap-2 text-sm">
-              <span className="text-muted-foreground">Line 1 â Wages for qualified services</span><span className="text-right font-mono">{fmt(form.line1_wages)}</span>
-              <span className="text-muted-foreground">Line 2 â Cost of supplies</span><span className="text-right font-mono">{fmt(form.line2_supplies)}</span>
-              <span className="text-muted-foreground">Line 3 â Contract research (65%)</span><span className="text-right font-mono">{fmt(form.line3_contractResearch)}</span>
-              <span className="text-muted-foreground font-semibold">Line 5 â Total QREs</span><span className="text-right font-mono font-semibold">{fmt(form.line5_totalQre)}</span>
+              <span className="text-muted-foreground">Line 1 — Wages for qualified services</span><span className="text-right font-mono">{fmt(form.line1_wages)}</span>
+              <span className="text-muted-foreground">Line 2 — Cost of supplies</span><span className="text-right font-mono">{fmt(form.line2_supplies)}</span>
+              <span className="text-muted-foreground">Line 3 — Contract research (65%)</span><span className="text-right font-mono">{fmt(form.line3_contractResearch)}</span>
+              <span className="text-muted-foreground font-semibold">Line 5 — Total QREs</span><span className="text-right font-mono font-semibold">{fmt(form.line5_totalQre)}</span>
             </div>
           </div>
 
@@ -742,12 +744,12 @@ function Form6765Tab({ studyId }: { studyId: number }) {
                   <span className="text-muted-foreground">Average Prior QRE</span><span className="text-right font-mono">{fmt(form.averagePriorQre)}</span>
                 </>
               )}
-              <span className="text-muted-foreground">Line 6 â Base amount</span><span className="text-right font-mono">{fmt(form.line6_baseAmount)}</span>
-              <span className="text-muted-foreground">Line 7 â QREs over base</span><span className="text-right font-mono">{fmt(form.line7_excessQre)}</span>
-              <span className="text-muted-foreground">Line 8 â Credit rate</span><span className="text-right font-mono">{((parseFloat(String(form.line8_creditRate ?? 0))) * 100).toFixed(0)}%</span>
-              <span className="text-muted-foreground font-semibold">Line 9 â Gross credit</span><span className="text-right font-mono font-semibold">{fmt(form.line9_grossCredit)}</span>
-              <span className="text-muted-foreground">Line 10 â Â§280C reduction</span><span className="text-right font-mono text-red-500">{fmt(form.line10_section280C)}</span>
-              <span className="text-muted-foreground font-bold">Line 11 â Net credit</span><span className="text-right font-mono font-bold text-green-600 text-lg">{fmt(form.line11_netCredit)}</span>
+              <span className="text-muted-foreground">Line 6 — Base amount</span><span className="text-right font-mono">{fmt(form.line6_baseAmount)}</span>
+              <span className="text-muted-foreground">Line 7 — QREs over base</span><span className="text-right font-mono">{fmt(form.line7_excessQre)}</span>
+              <span className="text-muted-foreground">Line 8 — Credit rate</span><span className="text-right font-mono">{((parseFloat(String(form.line8_creditRate ?? 0))) * 100).toFixed(0)}%</span>
+              <span className="text-muted-foreground font-semibold">Line 9 — Gross credit</span><span className="text-right font-mono font-semibold">{fmt(form.line9_grossCredit)}</span>
+              <span className="text-muted-foreground">Line 10 — §280C reduction</span><span className="text-right font-mono text-red-500">{fmt(form.line10_section280C)}</span>
+              <span className="text-muted-foreground font-bold">Line 11 — Net credit</span><span className="text-right font-mono font-bold text-green-600 text-lg">{fmt(form.line11_netCredit)}</span>
             </div>
           </div>
 
@@ -770,7 +772,7 @@ function Form6765Tab({ studyId }: { studyId: number }) {
   );
 }
 
-// Inline R&D % editor â click to edit, blur or Enter to save.
+// Inline R&D % editor — click to edit, blur or Enter to save.
 function InlineRdPercent({ value, onSave }: { value: number; onSave: (v: number) => void }) {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(String(value));
@@ -786,7 +788,6 @@ function InlineRdPercent({ value, onSave }: { value: number; onSave: (v: number)
       </button>
     );
   }
-
   const commit = () => {
     const n = parseFloat(draft);
     if (!isNaN(n) && n !== value) onSave(Math.max(0, Math.min(100, n)));
@@ -817,86 +818,80 @@ type QBImportCategory = "wages" | "supplies" | "contract_research" | "cloud_comp
 
 function ImportFromQBButton({ studyId, projects, onRefresh }: {
   studyId: number;
-  projects: Array<{ id?: number | null; projectName?: string | null }>;
+  projects: RdProjectRow[];
   onRefresh: () => void;
 }) {
   const [open, setOpen] = useState(false);
-      min={0}
-      max={100}
-      value={draft}
-      onChange={(e) => setDraft(e.target.value)}
-      onBlur={commit}
-      onKeyDown={(e) => {
-        if (e.key === "Enter") commit();
-        if (e.key === "Escape") setEditing(false);
-      }}
-      className="w-16 rounded border bg-background px-1 text-right text-sm"
-    />
-  );
-}
+  const [projectId, setProjectId] = useState("");
+  const [startDate, setStartDate] = useState(() => {
+    const d = new Date(); d.setMonth(0, 1); return d.toISOString().slice(0, 10);
+  });
+  const [endDate, setEndDate] = useState(() => new Date().toISOString().slice(0, 10));
+  const [category, setCategory] = useState<QBImportCategory>("wages");
 
-// ============================================
-// IMPORT FROM QB BUTTON (Issue #270)
-// ============================================
-type QBImportCategory = "wages" | "supplies" | "contract_research" | "cloud_computing";
+  const importMutation = trpc.rdTaxCredit.importFromQuickBooks.useMutation({
+    onSuccess: (data: any) => {
+      toast.success(`Imported ${data.imported ?? 0} expense(s) from QuickBooks`);
+      setOpen(false);
+      onRefresh();
+    },
+    onError: (e: any) => toast.error(e.message),
+  });
 
-function ImportFromQBButton({ studyId, projects, onRefresh }: {
-  studyId: number;
-  projects: Array<{ id?: number | null; projectName?: string | null }>;
-  onRefresh: () => void;
-}) {
-  const [open, setOpen] = useState(false);
-      min={0}
-      max={100}
-      value={draft}
-      onChange={(e) => setDraft(e.target.value)}
-      onBlur={commit}
-      onKeyDown={(e) => {
-        if (e.key === "Enter") commit();
-        if (e.key === "Escape") setEditing(false);
-      }}
-      className="w-16 rounded border bg-background px-1 text-right text-sm"
-    />
-  );
-}
-
-// ============================================
-// IMPORT FROM QB BUTTON (Issue #270)
-// ============================================
-type QBImportCategory = "wages" | "supplies" | "contract_research" | "cloud_computing";
-
-function ImportFromQBButton({ studyId, projects, onRefresh }: {
-  studyId: number;
-  projects: Array<{ id?: number | null; projectName?: string | null }>;
-  onRefresh: () => void;
-}) {
-  const [open, setOpen] = useState(false);
-      min={0}
-      max={100}
-      value={draft}
-      onChange={(e) => setDraft(e.target.value)}
-      onBlur={commit}
-      onKeyDown={(e) => {
-        if (e.key === "Enter") commit();
-        if (e.key === "Escape") setEditing(false);
-      }}
-      className="w-16 rounded border bg-background px-1 text-right text-sm"
-    />
-  );
-}
-
-// ============================================
-// IMPORT FROM QB BUTTON (Issue #270)
+  return (
+    <>
+      <Button size="sm" variant="outline" onClick={() => setOpen(true)}>
+        <Download className="h-4 w-4 mr-1" /> Import from QuickBooks
+      </Button>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>Import from QuickBooks</DialogTitle>
+            <DialogDescription>
+              Pull posted QuickBooks transactions matching the date range and category.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div>
+              <Label>Project</Label>
+              <Select value={projectId} onValueChange={setProjectId}>
+                <SelectTrigger><SelectValue placeholder="Select project" /></SelectTrigger>
+                <SelectContent>
+                  {projects.filter((p) => p.id != null).map((p) => (
+                    <SelectItem key={p.id} value={String(p.id)}>{p.projectName ?? `Project ${p.id}`}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
             <div className="grid grid-cols-2 gap-4">
               <div><Label>Start Date</Label><Input type="date" value={startDate} onChange={e => setStartDate(e.target.value)} /></div>
               <div><Label>End Date</Label><Input type="date" value={endDate} onChange={e => setEndDate(e.target.value)} /></div>
+            </div>
+            <div>
+              <Label>Category</Label>
+              <Select value={category} onValueChange={(v) => setCategory(v as QBImportCategory)}>
+                <SelectTrigger><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="wages">Employee Wages</SelectItem>
+                  <SelectItem value="supplies">Supplies</SelectItem>
+                  <SelectItem value="contract_research">Contract Research (65%)</SelectItem>
+                  <SelectItem value="cloud_computing">Cloud Computing</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setOpen(false)}>Cancel</Button>
+            <Button
+              onClick={() => importMutation.mutate({ studyId, projectId: parseInt(projectId), startDate, endDate, category })}
+              disabled={!projectId || importMutation.isPending}
+            >
+              {importMutation.isPending && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+              Import Expenses
+            </Button>
+          </DialogFooter>
+        </DialogContent>
       </Dialog>
     </>
-  );
-}
-  );
-}
-  );
-}
   );
 }

--- a/client/src/pages/finance/RdTaxCredit.tsx
+++ b/client/src/pages/finance/RdTaxCredit.tsx
@@ -830,12 +830,12 @@ function ImportFromQBButton({ studyId, projects, onRefresh }: {
   const [category, setCategory] = useState<QBImportCategory>("wages");
 
   const importMutation = trpc.rdTaxCredit.importFromQuickBooks.useMutation({
-    onSuccess: (data: any) => {
+    onSuccess: (data) => {
       toast.success(`Imported ${data.imported ?? 0} expense(s) from QuickBooks`);
       setOpen(false);
       onRefresh();
     },
-    onError: (e: any) => toast.error(e.message),
+    onError: (e) => toast.error(e.message),
   });
 
   return (
@@ -883,7 +883,7 @@ function ImportFromQBButton({ studyId, projects, onRefresh }: {
           <DialogFooter>
             <Button variant="outline" onClick={() => setOpen(false)}>Cancel</Button>
             <Button
-              onClick={() => importMutation.mutate({ studyId, projectId: parseInt(projectId), startDate, endDate, category })}
+              onClick={() => importMutation.mutate({ studyId, projectId: parseInt(projectId, 10), startDate, endDate, category })}
               disabled={!projectId || importMutation.isPending}
             >
               {importMutation.isPending && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}

--- a/client/src/pages/settings/ShopifySettings.tsx
+++ b/client/src/pages/settings/ShopifySettings.tsx
@@ -422,7 +422,7 @@ function AddLocationMappingButton({ storeId }: { storeId: number }) {
               onClick={() => createMapping.mutate({
                 storeId,
                 shopifyLocationId,
-                warehouseId: parseInt(warehouseId),
+                warehouseId: parseInt(warehouseId, 10),
               })}
               disabled={!shopifyLocationId || !warehouseId || createMapping.isPending}
             >

--- a/client/src/pages/settings/ShopifySettings.tsx
+++ b/client/src/pages/settings/ShopifySettings.tsx
@@ -422,13 +422,15 @@ function AddLocationMappingButton({ storeId }: { storeId: number }) {
               onClick={() => createMapping.mutate({
                 storeId,
                 shopifyLocationId,
-                                warehouseId: parseInt(warehouseId),
+                warehouseId: parseInt(warehouseId),
               })}
               disabled={!shopifyLocationId || !warehouseId || createMapping.isPending}
             >
               Create Mapping
             </Button>
           </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </>
   );
 }

--- a/scripts/strict-ratchet.mjs
+++ b/scripts/strict-ratchet.mjs
@@ -45,9 +45,19 @@ function runStrict() {
     if (output.trim()) console.error(output.trim());
     process.exit(2);
   }
-  // tsc exits 0 with no errors, 1 with type errors.
-  // Other exit codes (e.g. 2 for config/options errors) are fatal.
-  if (r.status !== 0 && r.status !== 1) {
+  // TypeScript exit codes:
+  //   0 = success (no diagnostics)
+  //   1 = DiagnosticsPresent_OutputsSkipped
+  //   2 = DiagnosticsPresent_OutputsGenerated
+  // All three mean the type-check ran to completion and its diagnostics are
+  // authoritative, so we parse the output in every case. Code 2 shows up here
+  // because the base tsconfig sets `incremental: true` + `noEmit: true`: on a
+  // run that has diagnostics, tsc still writes `.tsbuildinfo`, which counts as
+  // "outputs generated" and bumps the exit code from 1 to 2. That is why a
+  // fresh checkout (no cached .tsbuildinfo, e.g. every CI run) failed while a
+  // warm local run passed. Codes >= 3 are genuine project/config errors
+  // (InvalidProject, ProjectReferenceCycle, missing tooling) and stay fatal.
+  if (r.status !== 0 && r.status !== 1 && r.status !== 2) {
     console.error(
       `Strict typecheck failed with exit code ${r.status}. This usually indicates a tooling/config issue (e.g. pnpm not available or invalid TypeScript config).`,
     );


### PR DESCRIPTION
## Problem

`main` currently fails CI (Build, Type Check, Strict Ratchet). This PR fixes the three pre-existing, unrelated causes.

### 1. `RdTaxCredit.tsx` — build/type-check failure (syntax corruption)
Commit `a4bc470` ("Add R&D QB importer dialog", closes #270) inserted the `ImportFromQBButton` component **inside** the `InlineRdPercent` function, splitting it; a later merge duplicated the broken block into **four** mangled copies — orphaned JSX attributes (`min`/`max`/`value` with no opening tag), repeated banner comments, mismatched closings. Build error: `RdTaxCredit.tsx:824 Expected ":" but found "}"`.

### 2. `ShopifySettings.tsx` — build/type-check failure (unterminated JSX)
The `AddLocationMappingButton` dialog was missing its `</DialogContent>` and `</Dialog>` closing tags. Build error: `ShopifySettings.tsx:432 Unterminated JSX contents`.

### 3. Strict Ratchet — false failure on tsc exit code 2
The base tsconfig sets `incremental: true` + `noEmit: true`. On a run that has diagnostics, tsc still writes `.tsbuildinfo`, which counts as "outputs generated" and makes tsc exit **2** (`DiagnosticsPresent_OutputsGenerated`) instead of **1**. `scripts/strict-ratchet.mjs` treated any code other than 0/1 as a fatal tooling error and bailed. This is why CI's Strict Ratchet failed on **every fresh checkout** (no cached `.tsbuildinfo`) while warm local runs (code 1) passed.

## Fix

- **RdTaxCredit.tsx**: restored the clean `InlineRdPercent` and re-added a single, correctly-placed `ImportFromQBButton` (the QuickBooks import dialog intended by #270). `projects` prop typed `RdProjectRow[]` (exact type `ExpensesTab` passes) with nullable fields guarded; `importFromQuickBooks` call matches the server input schema.
- **ShopifySettings.tsx**: added the missing `</DialogContent>` / `</Dialog>` tags and fixed stray indentation; `createMapping` call matches the server input schema.
- **strict-ratchet.mjs**: accept exit code 2 as a valid diagnostics-present result (parse the output); codes ≥ 3 (invalid project / reference cycle / missing tooling) stay fatal.

## Verification (all pass locally)

- `pnpm build` ✓
- `pnpm check` (Type Check) ✓
- `pnpm check:strict` ✓
- `pnpm strict:check` (Strict Ratchet) ✓ — **reproduced CI's failure** by deleting `.tsbuildinfo` (tsc exit 2 → script bailed), confirmed fixed: fresh runs now report "Strict ratchet OK" (141 vs baseline 142), exit 0
- `pnpm test` ✓ — 868 tests across 51 files

## Relationship to #294

#294 (data-room Drive sync) is unrelated and was only red because it inherited this same pre-existing breakage from `main`. Once this merges, #294's CI should go green after a rebase.

https://claude.ai/code/session_017nheZpevWgGSQTctyfsygu