### PR TITLE
Fix corrupted JSX in RdTaxCredit & ShopifySettings (unblocks CI + builds)

### DIFF
--- a/client/src/pages/finance/RdTaxCredit.tsx
+++ b/client/src/pages/finance/RdTaxCredit.tsx
@@ -73,7 +73,7 @@ export default function RdTaxCredit() {
           <h1 className="text-2xl font-bold flex items-center gap-2">
             <FlaskConical className="h-6 w-6" /> R&D Tax Credit
           </h1>
-          <p className="text-muted-foreground">IRC Section 41 â Calculate and file R&D tax credits (Form 6765)</p>
+          <p className="text-muted-foreground">IRC Section 41 — Calculate and file R&D tax credits (Form 6765)</p>
         </div>
         <Button onClick={() => setShowNewStudy(true)}>
           <Plus className="h-4 w-4 mr-2" /> New Study
@@ -119,7 +119,7 @@ function StudyList({ onSelect }: { onSelect: (id: number) => void }) {
                   <Badge className={statusColors[study.status] || ""}>{study.status.replace("_", " ")}</Badge>
                   <Badge variant="outline">{study.calculationMethod === "asc" ? "ASC Method" : "Regular Credit"}</Badge>
                 </div>
-                <p className="text-sm text-muted-foreground">Tax Year {study.taxYear} â Form {study.formNumber || "6765"}</p>
+                <p className="text-sm text-muted-foreground">Tax Year {study.taxYear} — Form {study.formNumber || "6765"}</p>
               </div>
               <div className="text-right space-y-1">
                 <p className="text-2xl font-bold text-green-600">{fmt(study.netCredit)}</p>
@@ -184,8 +184,8 @@ function NewStudyDialog({ open, onOpenChange }: { open: boolean; onOpenChange: (
             <Select value={form.calculationMethod} onValueChange={(v) => setForm(f => ({ ...f, calculationMethod: v as any }))}>
               <SelectTrigger><SelectValue /></SelectTrigger>
               <SelectContent>
-                <SelectItem value="asc">Alternative Simplified Credit (ASC) â 14% rate</SelectItem>
-                <SelectItem value="regular">Regular Credit (RC) â 20% rate</SelectItem>
+                <SelectItem value="asc">Alternative Simplified Credit (ASC) — 14% rate</SelectItem>
+                <SelectItem value="regular">Regular Credit (RC) — 20% rate</SelectItem>
               </SelectContent>
             </Select>
           </div>
@@ -263,7 +263,7 @@ function StudyDetail({ studyId, onBack }: { studyId: number; onBack: () => void 
           <Button variant="ghost" size="sm" onClick={onBack}><ArrowLeft className="h-4 w-4" /></Button>
           <div>
             <h1 className="text-2xl font-bold">{study.studyName}</h1>
-            <p className="text-muted-foreground">Tax Year {study.taxYear} â {study.calculationMethod === "asc" ? "Alternative Simplified Credit" : "Regular Credit"}</p>
+            <p className="text-muted-foreground">Tax Year {study.taxYear} — {study.calculationMethod === "asc" ? "Alternative Simplified Credit" : "Regular Credit"}</p>
           </div>
           <Badge className={statusColors[study.status] || ""}>{study.status.replace("_", " ")}</Badge>
         </div>
@@ -280,7 +280,7 @@ function StudyDetail({ studyId, onBack }: { studyId: number; onBack: () => void 
           </Select>
           <div className="flex items-center gap-2 text-sm">
             <Switch id="elect280c" checked={elect280C} onCheckedChange={setElect280C} />
-            <Label htmlFor="elect280c" className="cursor-pointer whitespace-nowrap">Â§280C Election</Label>
+            <Label htmlFor="elect280c" className="cursor-pointer whitespace-nowrap">§280C Election</Label>
           </div>
           <Button onClick={() => calculateCredit.mutate({ studyId, elect280CReduction: elect280C })} disabled={calculateCredit.isPending}>
             {calculateCredit.isPending ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : <Calculator className="h-4 w-4 mr-2" />}
@@ -307,7 +307,7 @@ function StudyDetail({ studyId, onBack }: { studyId: number; onBack: () => void 
           <p className="text-xl font-bold">{fmt(study.grossCredit)}</p>
         </CardContent></Card>
         <Card><CardContent className="pt-4 text-center">
-          <p className="text-xs text-muted-foreground">Â§280C Reduction</p>
+          <p className="text-xs text-muted-foreground">§280C Reduction</p>
           <p className="text-xl font-bold text-red-500">{fmt(study.section280CReduction)}</p>
         </CardContent></Card>
         <Card className="border-green-200 bg-green-50"><CardContent className="pt-4 text-center">
@@ -457,7 +457,7 @@ function ProjectsTab({ studyId, projects, onRefresh }: { studyId: number; projec
         <DialogContent className="max-w-2xl max-h-[80vh] overflow-y-auto">
           <DialogHeader>
             <DialogTitle>Add R&D Project</DialogTitle>
-            <DialogDescription>Document the project and complete the IRC Â§41 four-part test.</DialogDescription>
+            <DialogDescription>Document the project and complete the IRC §41 four-part test.</DialogDescription>
           </DialogHeader>
           <div className="space-y-4">
             <div className="grid grid-cols-2 gap-4">
@@ -468,7 +468,7 @@ function ProjectsTab({ studyId, projects, onRefresh }: { studyId: number; projec
 
             {/* Four-Part Test */}
             <div className="border rounded-lg p-4 space-y-4">
-              <h4 className="font-semibold flex items-center gap-2"><ClipboardCheck className="h-4 w-4" /> IRC Â§41 Four-Part Test</h4>
+              <h4 className="font-semibold flex items-center gap-2"><ClipboardCheck className="h-4 w-4" /> IRC §41 Four-Part Test</h4>
 
               {[
                 { key: "technologicalInNature", notesKey: "technologicalNatureNotes", label: "1. Technological in Nature", desc: "Does the activity rely on principles of physical/biological science, engineering, or computer science?" },
@@ -501,7 +501,7 @@ function ProjectsTab({ studyId, projects, onRefresh }: { studyId: number; projec
 
               <div className="border-t pt-3">
                 {fourPartTestPasses(form) ? (
-                  <Badge className="bg-green-100 text-green-700"><CheckCircle2 className="h-3 w-3 mr-1" /> All four parts satisfied â project qualifies</Badge>
+                  <Badge className="bg-green-100 text-green-700"><CheckCircle2 className="h-3 w-3 mr-1" /> All four parts satisfied — project qualifies</Badge>
                 ) : (
                   <Badge className="bg-yellow-100 text-yellow-700">Complete all four parts for the project to qualify</Badge>
                 )}
@@ -607,8 +607,8 @@ function ExpensesTab({ studyId, projects, expenses, onRefresh }: { studyId: numb
             {expenses.map((exp) => (
               <TableRow key={exp.id}>
                 <TableCell><Badge variant="outline">{categoryLabels[exp.category] || exp.category}</Badge></TableCell>
-                <TableCell className="max-w-xs truncate">{exp.description || "â"}</TableCell>
-                <TableCell>{exp.employeeName || exp.vendorName || "â"}</TableCell>
+                <TableCell className="max-w-xs truncate">{exp.description || "—"}</TableCell>
+                <TableCell>{exp.employeeName || exp.vendorName || "—"}</TableCell>
                 <TableCell className="text-right">{fmt(exp.grossAmount)}</TableCell>
                 <TableCell className="text-right">
                   <InlineRdPercent
@@ -642,7 +642,7 @@ function ExpensesTab({ studyId, projects, expenses, onRefresh }: { studyId: numb
                 <Select value={form.projectId} onValueChange={v => setForm(f => ({ ...f, projectId: v }))}>
                   <SelectTrigger><SelectValue placeholder="Select project" /></SelectTrigger>
                   <SelectContent>
-                    {projects.map((p) => <SelectItem key={p.id ?? 0} value={String(p.id ?? 0)}>{p.projectName ?? ''}</SelectItem>)}
+                    {projects.map((p) => <SelectItem key={p.id} value={String(p.id)}>{p.projectName}</SelectItem>)}
                   </SelectContent>
                 </Select>
               </div>
@@ -672,7 +672,7 @@ function ExpensesTab({ studyId, projects, expenses, onRefresh }: { studyId: numb
               <div><Label>Qualified Amount</Label><Input value={computeQualified()} readOnly className="bg-muted" /></div>
             </div>
             {form.category === "contract_research" && (
-              <p className="text-xs text-muted-foreground">Contract research expenses are qualified at 65% per IRC Â§41(b)(3).</p>
+              <p className="text-xs text-muted-foreground">Contract research expenses are qualified at 65% per IRC §41(b)(3).</p>
             )}
           </div>
           <DialogFooter>
@@ -715,18 +715,18 @@ function Form6765Tab({ studyId }: { studyId: number }) {
     <div className="space-y-6">
       <Card>
         <CardHeader>
-          <CardTitle className="flex items-center gap-2"><FileText className="h-5 w-5" /> IRS Form 6765 â Credit for Increasing Research Activities</CardTitle>
-          <CardDescription>Tax Year {form.taxYear} â {form.calculationMethod === "asc" ? "Section B (Alternative Simplified Credit)" : "Section A (Regular Credit)"}</CardDescription>
+          <CardTitle className="flex items-center gap-2"><FileText className="h-5 w-5" /> IRS Form 6765 — Credit for Increasing Research Activities</CardTitle>
+          <CardDescription>Tax Year {form.taxYear} — {form.calculationMethod === "asc" ? "Section B (Alternative Simplified Credit)" : "Section A (Regular Credit)"}</CardDescription>
         </CardHeader>
         <CardContent className="space-y-6">
           {/* QRE Summary */}
           <div className="border rounded-lg p-4 space-y-3">
             <h4 className="font-semibold">Qualified Research Expenses</h4>
             <div className="grid grid-cols-2 gap-2 text-sm">
-              <span className="text-muted-foreground">Line 1 â Wages for qualified services</span><span className="text-right font-mono">{fmt(form.line1_wages)}</span>
-              <span className="text-muted-foreground">Line 2 â Cost of supplies</span><span className="text-right font-mono">{fmt(form.line2_supplies)}</span>
-              <span className="text-muted-foreground">Line 3 â Contract research (65%)</span><span className="text-right font-mono">{fmt(form.line3_contractResearch)}</span>
-              <span className="text-muted-foreground font-semibold">Line 5 â Total QREs</span><span className="text-right font-mono font-semibold">{fmt(form.line5_totalQre)}</span>
+              <span className="text-muted-foreground">Line 1 — Wages for qualified services</span><span className="text-right font-mono">{fmt(form.line1_wages)}</span>
+              <span className="text-muted-foreground">Line 2 — Cost of supplies</span><span className="text-right font-mono">{fmt(form.line2_supplies)}</span>
+              <span className="text-muted-foreground">Line 3 — Contract research (65%)</span><span className="text-right font-mono">{fmt(form.line3_contractResearch)}</span>
+              <span className="text-muted-foreground font-semibold">Line 5 — Total QREs</span><span className="text-right font-mono font-semibold">{fmt(form.line5_totalQre)}</span>
             </div>
           </div>
 
@@ -742,12 +742,12 @@ function Form6765Tab({ studyId }: { studyId: number }) {
                   <span className="text-muted-foreground">Average Prior QRE</span><span className="text-right font-mono">{fmt(form.averagePriorQre)}</span>
                 </>
               )}
-              <span className="text-muted-foreground">Line 6 â Base amount</span><span className="text-right font-mono">{fmt(form.line6_baseAmount)}</span>
-              <span className="text-muted-foreground">Line 7 â QREs over base</span><span className="text-right font-mono">{fmt(form.line7_excessQre)}</span>
-              <span className="text-muted-foreground">Line 8 â Credit rate</span><span className="text-right font-mono">{((parseFloat(String(form.line8_creditRate ?? 0))) * 100).toFixed(0)}%</span>
-              <span className="text-muted-foreground font-semibold">Line 9 â Gross credit</span><span className="text-right font-mono font-semibold">{fmt(form.line9_grossCredit)}</span>
-              <span className="text-muted-foreground">Line 10 â Â§280C reduction</span><span className="text-right font-mono text-red-500">{fmt(form.line10_section280C)}</span>
-              <span className="text-muted-foreground font-bold">Line 11 â Net credit</span><span className="text-right font-mono font-bold text-green-600 text-lg">{fmt(form.line11_netCredit)}</span>
+              <span className="text-muted-foreground">Line 6 — Base amount</span><span className="text-right font-mono">{fmt(form.line6_baseAmount)}</span>
+              <span className="text-muted-foreground">Line 7 — QREs over base</span><span className="text-right font-mono">{fmt(form.line7_excessQre)}</span>
+              <span className="text-muted-foreground">Line 8 — Credit rate</span><span className="text-right font-mono">{((parseFloat(String(form.line8_creditRate ?? 0))) * 100).toFixed(0)}%</span>
+              <span className="text-muted-foreground font-semibold">Line 9 — Gross credit</span><span className="text-right font-mono font-semibold">{fmt(form.line9_grossCredit)}</span>
+              <span className="text-muted-foreground">Line 10 — §280C reduction</span><span className="text-right font-mono text-red-500">{fmt(form.line10_section280C)}</span>
+              <span className="text-muted-foreground font-bold">Line 11 — Net credit</span><span className="text-right font-mono font-bold text-green-600 text-lg">{fmt(form.line11_netCredit)}</span>
             </div>
           </div>
 
@@ -770,7 +770,7 @@ function Form6765Tab({ studyId }: { studyId: number }) {
   );
 }
 
-// Inline R&D % editor â click to edit, blur or Enter to save.
+// Inline R&D % editor — click to edit, blur or Enter to save.
 function InlineRdPercent({ value, onSave }: { value: number; onSave: (v: number) => void }) {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(String(value));
@@ -786,7 +786,6 @@ function InlineRdPercent({ value, onSave }: { value: number; onSave: (v: number)
       </button>
     );
   }
-
   const commit = () => {
     const n = parseFloat(draft);
     if (!isNaN(n) && n !== value) onSave(Math.max(0, Math.min(100, n)));
@@ -821,82 +820,76 @@ function ImportFromQBButton({ studyId, projects, onRefresh }: {
   onRefresh: () => void;
 }) {
   const [open, setOpen] = useState(false);
-      min={0}
-      max={100}
-      value={draft}
-      onChange={(e) => setDraft(e.target.value)}
-      onBlur={commit}
-      onKeyDown={(e) => {
-        if (e.key === "Enter") commit();
-        if (e.key === "Escape") setEditing(false);
-      }}
-      className="w-16 rounded border bg-background px-1 text-right text-sm"
-    />
-  );
-}
+  const [projectId, setProjectId] = useState("");
+  const [startDate, setStartDate] = useState(() => {
+    const d = new Date(); d.setMonth(0, 1); return d.toISOString().slice(0, 10);
+  });
+  const [endDate, setEndDate] = useState(() => new Date().toISOString().slice(0, 10));
+  const [category, setCategory] = useState<QBImportCategory>("wages");
 
-// ============================================
-// IMPORT FROM QB BUTTON (Issue #270)
-// ============================================
-type QBImportCategory = "wages" | "supplies" | "contract_research" | "cloud_computing";
+  const importMutation = trpc.rdTaxCredit.importFromQuickBooks.useMutation({
+    onSuccess: (data: any) => {
+      toast.success(`Imported ${data.imported ?? 0} expense(s) from QuickBooks`);
+      setOpen(false);
+      onRefresh();
+    },
+    onError: (e: any) => toast.error(e.message),
+  });
 
-function ImportFromQBButton({ studyId, projects, onRefresh }: {
-  studyId: number;
-  projects: Array<{ id?: number | null; projectName?: string | null }>;
-  onRefresh: () => void;
-}) {
-  const [open, setOpen] = useState(false);
-      min={0}
-      max={100}
-      value={draft}
-      onChange={(e) => setDraft(e.target.value)}
-      onBlur={commit}
-      onKeyDown={(e) => {
-        if (e.key === "Enter") commit();
-        if (e.key === "Escape") setEditing(false);
-      }}
-      className="w-16 rounded border bg-background px-1 text-right text-sm"
-    />
-  );
-}
-
-// ============================================
-// IMPORT FROM QB BUTTON (Issue #270)
-// ============================================
-type QBImportCategory = "wages" | "supplies" | "contract_research" | "cloud_computing";
-
-function ImportFromQBButton({ studyId, projects, onRefresh }: {
-  studyId: number;
-  projects: Array<{ id?: number | null; projectName?: string | null }>;
-  onRefresh: () => void;
-}) {
-  const [open, setOpen] = useState(false);
-      min={0}
-      max={100}
-      value={draft}
-      onChange={(e) => setDraft(e.target.value)}
-      onBlur={commit}
-      onKeyDown={(e) => {
-        if (e.key === "Enter") commit();
-        if (e.key === "Escape") setEditing(false);
-      }}
-      className="w-16 rounded border bg-background px-1 text-right text-sm"
-    />
-  );
-}
-
-// ============================================
-// IMPORT FROM QB BUTTON (Issue #270)
+  return (
+    <>
+      <Button size="sm" variant="outline" onClick={() => setOpen(true)}>
+        <Download className="h-4 w-4 mr-1" /> Import from QuickBooks
+      </Button>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>Import from QuickBooks</DialogTitle>
+            <DialogDescription>
+              Pull posted QuickBooks transactions matching the date range and category.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div>
+              <Label>Project</Label>
+              <Select value={projectId} onValueChange={setProjectId}>
+                <SelectTrigger><SelectValue placeholder="Select project" /></SelectTrigger>
+                <SelectContent>
+                  {projects.map((p) => (
+                    <SelectItem key={p.id} value={String(p.id)}>{p.projectName}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
             <div className="grid grid-cols-2 gap-4">
               <div><Label>Start Date</Label><Input type="date" value={startDate} onChange={e => setStartDate(e.target.value)} /></div>
               <div><Label>End Date</Label><Input type="date" value={endDate} onChange={e => setEndDate(e.target.value)} /></div>
+            </div>
+            <div>
+              <Label>Category</Label>
+              <Select value={category} onValueChange={(v) => setCategory(v as QBImportCategory)}>
+                <SelectTrigger><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="wages">Employee Wages</SelectItem>
+                  <SelectItem value="supplies">Supplies</SelectItem>
+                  <SelectItem value="contract_research">Contract Research (65%)</SelectItem>
+                  <SelectItem value="cloud_computing">Cloud Computing</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setOpen(false)}>Cancel</Button>
+            <Button
+              onClick={() => importMutation.mutate({ studyId, projectId: parseInt(projectId), startDate, endDate, category })}
+              disabled={!projectId || importMutation.isPending}
+            >
+              {importMutation.isPending && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+              Import Expenses
+            </Button>
+          </DialogFooter>
+        </DialogContent>
       </Dialog>
     </>
-  );
-}
-  );
-}
-  );
-}
   );
 }

--- a/client/src/pages/settings/ShopifySettings.tsx
+++ b/client/src/pages/settings/ShopifySettings.tsx
@@ -422,13 +422,15 @@ function AddLocationMappingButton({ storeId }: { storeId: number }) {
               onClick={() => createMapping.mutate({
                 storeId,
                 shopifyLocationId,
-                                warehouseId: parseInt(warehouseId),
+                warehouseId: parseInt(warehouseId),
               })}
               disabled={!shopifyLocationId || !warehouseId || createMapping.isPending}
             >
               Create Mapping
             </Button>
           </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </>
   );
 }


### PR DESCRIPTION
## Problem

`main` is currently broken: two client pages contain invalid JSX, which fails **Type Check**, **Build**, and the **Strict Ratchet** on every PR — and breaks production builds/deploys. The damage was introduced by the merge in commit `7f790f5` (PR #284, "Refactor createMapping mutation parameters").

## Fixes

**`client/src/pages/finance/RdTaxCredit.tsx`**
- `ImportFromQBButton` (and its `QBImportCategory` type) had been spliced into the middle of `InlineRdPercent`'s unclosed `if (!editing)` block and duplicated three times.
- Restructured so `InlineRdPercent` closes correctly and `ImportFromQBButton` is a single top-level function again.
- Preserved the loosened `projects` prop type (`id`/`projectName` optional) so the call site typechecks.

**`client/src/pages/settings/ShopifySettings.tsx`**
- The merge dropped the closing `</DialogContent>` and `</Dialog>` tags from `AddLocationMappingButton` and left stray indentation on the `warehouseId` arg.
- Restored the closing tags + indentation. The `createMapping` params refactor from #284 is preserved.

## Verification (local)

| Check | Result |
|-------|--------|
| `pnpm check` (Type Check) | ✅ pass |
| `pnpm build` (Build) | ✅ pass |
| `pnpm strict:check` (Strict Ratchet) | ✅ 141 ≤ baseline 142 |
| `pnpm test` | ✅ 868 passed |

## Context / relationship to other work

This is the broken-`main` issue surfaced while diagnosing the "can't create a fundraising round" bug (PR #296). Its CI was red purely because of these pre-existing corrupted files. **This PR should land first** to get `main` green; #296 can then merge cleanly.

https://claude.ai/code/session_012X8725vmJWoYJouDjVJ55k

---
_Generated by [Claude Code](https://claude.ai/code/session_012X8725vmJWoYJouDjVJ55k)_