### PR TITLE
Fix Strict Ratchet aborting on tsc cold-build exit code 2

### DIFF
--- a/scripts/strict-ratchet.mjs
+++ b/scripts/strict-ratchet.mjs
@@ -45,9 +45,17 @@ function runStrict() {
     if (output.trim()) console.error(output.trim());
     process.exit(2);
   }
-  // tsc exits 0 with no errors, 1 with type errors.
-  // Other exit codes (e.g. 2 for config/options errors) are fatal.
-  if (r.status !== 0 && r.status !== 1) {
+  // tsc exit codes (see TS ExitStatus):
+  //   0 = no errors
+  //   1 = DiagnosticsPresent_OutputsSkipped  (type errors, nothing emitted)
+  //   2 = DiagnosticsPresent_OutputsGenerated (type errors; with --noEmit this
+  //       still occurs on a *cold* build because the .tsbuildinfo from
+  //       `incremental` counts as an emitted output). CI checks out fresh with
+  //       no cached .tsbuildinfo, so 2 is the normal "errors present" status
+  //       there — the diagnostics are still printed and parseable.
+  // Both 1 and 2 carry the diagnostics we parse below. Anything else
+  // (e.g. 3 InvalidProject) is a genuine tooling/config failure.
+  if (r.status !== 0 && r.status !== 1 && r.status !== 2) {
     console.error(
       `Strict typecheck failed with exit code ${r.status}. This usually indicates a tooling/config issue (e.g. pnpm not available or invalid TypeScript config).`,
     );


### PR DESCRIPTION
## Problem

The **Strict Ratchet** CI check fails on every fresh run (including `main`), independent of the PR's contents.

`scripts/strict-ratchet.mjs` runs `tsc --noEmit` and treats any exit code other than `0`/`1` as a fatal tooling error:

```js
if (r.status !== 0 && r.status !== 1) { /* abort, exit 2 */ }
```

But the root `tsconfig.json` sets `"incremental": true` with a `.tsbuildinfo` file. On a **cold** checkout (CI caches only the pnpm store, never `.tsbuildinfo`), `tsc --noEmit` still writes the buildinfo — which counts as an emitted output — so when type errors are present tsc exits with code **2** (`DiagnosticsPresent_OutputsGenerated`) instead of `1`. The diagnostics are identical and fully parseable, but the script bailed out and failed the job.

Locally this is masked: a repeat run has a current `.tsbuildinfo`, so tsc exits `1` and the ratchet passes — which is why it looked fine on dev machines.

## Fix

Accept exit code `2` alongside `0`/`1`. The per-file regression comparison against `.strict-baseline.json` is unchanged, so this does **not** weaken the gate — it just stops aborting on tsc's normal cold-build error status. Genuine tooling failures (exit 3+, spawn errors, `null` status) are still fatal.

## Verification

On a cold build (`.tsbuildinfo` deleted):
- Before: ratchet aborts — "Strict typecheck failed with exit code 2".
- After: ratchet runs and compares to baseline. On clean code → `Strict ratchet OK. Total errors: 141 (baseline 142)` (exit 0).

## ⚠️ Merge-order note (interdependency)

For the **Strict Ratchet** check to actually go green, two independent things are both required:
1. **This PR** — so the script stops aborting on cold-build exit 2.
2. **#299** — which repairs the corrupted JSX in `RdTaxCredit.tsx` / `ShopifySettings.tsx`. Until that lands, this now-functional ratchet correctly reports those files as real regressions (RdTaxCredit 0→41, ShopifySettings 0→5).

So this PR's own Strict Ratchet will stay red (correctly flagging `main`'s corruption) until #299 is merged. Recommended order: merge **#299**, then this. Type Check / Build are unaffected by this PR.

https://claude.ai/code/session_012X8725vmJWoYJouDjVJ55k

---
_Generated by [Claude Code](https://claude.ai/code/session_012X8725vmJWoYJouDjVJ55k)_