### PR TITLE
Migration 0046: add ALL missing fundraising_campaigns columns (fixes deploy failure)

### DIFF
--- a/drizzle/0046_ensure_fundraising_campaigns_companyid.sql
+++ b/drizzle/0046_ensure_fundraising_campaigns_companyid.sql
@@ -1,38 +1,95 @@
--- Migration 0046: Ensure fundraising_campaigns schema is correct.
--- Migration 0041 (which itself re-applied the never-journaled 0027 fix) was
--- assigned a regenerated, out-of-order `when` timestamp during a journal
--- rewrite. Drizzle's mysql2 migrator decides what to run by comparing each
--- journal entry's `when` against the latest timestamp recorded in
--- `__drizzle_migrations`, so 0041 was silently skipped on databases whose
--- recorded timestamp was already newer. The result: the `companyId` column was
--- never added, and `INSERT INTO fundraising_campaigns (..., companyId, ...)`
--- fails with "Unknown column 'companyId'" when creating a fundraising round.
+-- Migration 0046: Ensure the fundraising_campaigns table matches the schema.
 --
--- This migration has a fresh (newest) timestamp so it is guaranteed to run, and
--- it is fully idempotent (MySQL 8.0 has no ADD COLUMN IF NOT EXISTS, so we use a
--- stored procedure to guard the change).
+-- The production table was created with only a subset of the columns defined in
+-- drizzle/schema.ts (the original 0023 CREATE TABLE and the 0027/0041 fixes
+-- never fully applied). As a result INSERTs that reference columns such as
+-- `companyId` and `createdBy` fail with "Unknown column ...", so creating a
+-- fundraising round errors out.
+--
+-- This migration is fully idempotent: for every column the schema expects it
+-- adds the column only if it is missing (MySQL 8.0 has no ADD COLUMN IF NOT
+-- EXISTS, so each is guarded via INFORMATION_SCHEMA), then normalizes the
+-- nullability/defaults that earlier partial migrations were meant to set. It is
+-- safe to run repeatedly and against a table in any partial state. `id` and
+-- `name` are intentionally not touched — they are the table's primary key and
+-- required name and are always present.
 
 DROP PROCEDURE IF EXISTS `_ensure_fundraising_campaigns_schema`;
 --> statement-breakpoint
 CREATE PROCEDURE `_ensure_fundraising_campaigns_schema`()
 BEGIN
-  -- Add companyId if it doesn't exist
-  IF NOT EXISTS (
-    SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
-    WHERE TABLE_SCHEMA = DATABASE()
-      AND TABLE_NAME = 'fundraising_campaigns'
-      AND COLUMN_NAME = 'companyId'
-  ) THEN
-    ALTER TABLE `fundraising_campaigns` ADD COLUMN `companyId` int AFTER `id`;
+  IF NOT EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'fundraising_campaigns' AND COLUMN_NAME = 'companyId') THEN
+    ALTER TABLE `fundraising_campaigns` ADD COLUMN `companyId` int;
   END IF;
 
-  -- Make createdBy nullable (was NOT NULL in the original 0023 migration)
+  IF NOT EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'fundraising_campaigns' AND COLUMN_NAME = 'description') THEN
+    ALTER TABLE `fundraising_campaigns` ADD COLUMN `description` text;
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'fundraising_campaigns' AND COLUMN_NAME = 'targetAmount') THEN
+    ALTER TABLE `fundraising_campaigns` ADD COLUMN `targetAmount` decimal(15,2);
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'fundraising_campaigns' AND COLUMN_NAME = 'raisedAmount') THEN
+    ALTER TABLE `fundraising_campaigns` ADD COLUMN `raisedAmount` decimal(15,2) DEFAULT '0';
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'fundraising_campaigns' AND COLUMN_NAME = 'minimumInvestment') THEN
+    ALTER TABLE `fundraising_campaigns` ADD COLUMN `minimumInvestment` decimal(15,2);
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'fundraising_campaigns' AND COLUMN_NAME = 'valuation') THEN
+    ALTER TABLE `fundraising_campaigns` ADD COLUMN `valuation` decimal(15,2);
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'fundraising_campaigns' AND COLUMN_NAME = 'roundType') THEN
+    ALTER TABLE `fundraising_campaigns` ADD COLUMN `roundType` enum('pre_seed','seed','series_a','series_b','series_c','bridge','other') NOT NULL DEFAULT 'seed';
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'fundraising_campaigns' AND COLUMN_NAME = 'equityOffered') THEN
+    ALTER TABLE `fundraising_campaigns` ADD COLUMN `equityOffered` decimal(5,2);
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'fundraising_campaigns' AND COLUMN_NAME = 'startDate') THEN
+    ALTER TABLE `fundraising_campaigns` ADD COLUMN `startDate` timestamp NULL;
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'fundraising_campaigns' AND COLUMN_NAME = 'targetCloseDate') THEN
+    ALTER TABLE `fundraising_campaigns` ADD COLUMN `targetCloseDate` timestamp NULL;
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'fundraising_campaigns' AND COLUMN_NAME = 'actualCloseDate') THEN
+    ALTER TABLE `fundraising_campaigns` ADD COLUMN `actualCloseDate` timestamp NULL;
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'fundraising_campaigns' AND COLUMN_NAME = 'status') THEN
+    ALTER TABLE `fundraising_campaigns` ADD COLUMN `status` enum('planning','active','paused','closed','cancelled') NOT NULL DEFAULT 'planning';
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'fundraising_campaigns' AND COLUMN_NAME = 'dataRoomId') THEN
+    ALTER TABLE `fundraising_campaigns` ADD COLUMN `dataRoomId` int;
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'fundraising_campaigns' AND COLUMN_NAME = 'notes') THEN
+    ALTER TABLE `fundraising_campaigns` ADD COLUMN `notes` text;
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'fundraising_campaigns' AND COLUMN_NAME = 'createdBy') THEN
+    ALTER TABLE `fundraising_campaigns` ADD COLUMN `createdBy` int;
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'fundraising_campaigns' AND COLUMN_NAME = 'createdAt') THEN
+    ALTER TABLE `fundraising_campaigns` ADD COLUMN `createdAt` timestamp NOT NULL DEFAULT (now());
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'fundraising_campaigns' AND COLUMN_NAME = 'updatedAt') THEN
+    ALTER TABLE `fundraising_campaigns` ADD COLUMN `updatedAt` timestamp NOT NULL DEFAULT (now()) ON UPDATE CURRENT_TIMESTAMP;
+  END IF;
+
+  -- Normalize columns that earlier partial migrations were meant to relax /
+  -- default. Safe now that every column above is guaranteed to exist.
   ALTER TABLE `fundraising_campaigns` MODIFY COLUMN `createdBy` int NULL;
-
-  -- Make targetAmount nullable (was NOT NULL in the original 0023 migration)
   ALTER TABLE `fundraising_campaigns` MODIFY COLUMN `targetAmount` decimal(15,2) NULL;
-
-  -- Ensure roundType has a DEFAULT 'seed'
   ALTER TABLE `fundraising_campaigns`
     MODIFY COLUMN `roundType` enum('pre_seed','seed','series_a','series_b','series_c','bridge','other') NOT NULL DEFAULT 'seed';
 END;


### PR DESCRIPTION
## Problem

The production "Deploy to Production" run **did** execute migration `0046` now, but it failed:

```
[migrate] Migration failed: ER_BAD_FIELD_ERROR
CALL `_ensure_fundraising_campaigns_schema`();
cause: Unknown column 'createdBy' in 'fundraising_campaigns'
```

So the live `fundraising_campaigns` table is missing **more than just `companyId`** — it also lacks `createdBy` (and likely other columns). The table was created with only a subset of the schema's columns; the original `0023` CREATE TABLE and the `0027`/`0041` fixes never fully applied. The previous `0046` assumed `companyId` was the only gap and went straight to `MODIFY createdBy`, which blew up.

Because the migration **threw**, drizzle never recorded it as applied — so it would re-run and re-fail on every deploy, blocking everything.

## Fix

Rewrite `0046` to idempotently **ADD every column the schema expects** (only when missing, guarded via `INFORMATION_SCHEMA` since MySQL 8 has no `ADD COLUMN IF NOT EXISTS`), then normalize the nullability/defaults:

`companyId, description, targetAmount, raisedAmount, minimumInvestment, valuation, roundType, equityOffered, startDate, targetCloseDate, actualCloseDate, status, dataRoomId, notes, createdBy, createdAt, updatedAt`

- Fully idempotent — safe to run repeatedly and against a table in any partial state (it already added `companyId` on the failed prod run; that's now skipped).
- `id` and `name` are left untouched (always present; `name` is `NOT NULL` with no default).
- All added columns are nullable or have defaults, so existing rows are safe.

## Note on testing

Docker has no running daemon in this environment, so I couldn't spin up MySQL 8 to live-test. The stored-procedure shape is already proven to execute on the target DB (the prior run failed at *runtime* on the missing column, not on syntax), and the SQL uses only constructs `0023`/`0041` already used there.

## Rollout
1. Merge this.
2. Re-run **Actions → "Deploy to Production" → `deploy`**. The migrate step should now succeed and bring the table fully in line with the schema.
3. Creating a fundraising round will work.

(Independent of #303, which makes push-to-`main` deploys run migrations automatically going forward.)

https://claude.ai/code/session_012X8725vmJWoYJouDjVJ55k

---
_Generated by [Claude Code](https://claude.ai/code/session_012X8725vmJWoYJouDjVJ55k)_