### PR TITLE
Harden strict ratchet + R&D import date/typing nits

### DIFF
--- a/client/src/pages/finance/RdTaxCredit.tsx
+++ b/client/src/pages/finance/RdTaxCredit.tsx
@@ -814,6 +814,12 @@ function InlineRdPercent({ value, onSave }: { value: number; onSave: (v: number)
 // ============================================
 type QBImportCategory = "wages" | "supplies" | "contract_research" | "cloud_computing";
 
+// Local-time YYYY-MM-DD for <input type="date">. Using toISOString() directly
+// would format in UTC and shift the day for users in non-zero timezones.
+function toDateInputValue(d: Date) {
+  return new Date(d.getTime() - d.getTimezoneOffset() * 60000).toISOString().slice(0, 10);
+}
+
 function ImportFromQBButton({ studyId, projects, onRefresh }: {
   studyId: number;
   projects: Array<{ id?: number | null; projectName?: string | null }>;
@@ -822,18 +828,18 @@ function ImportFromQBButton({ studyId, projects, onRefresh }: {
   const [open, setOpen] = useState(false);
   const [projectId, setProjectId] = useState("");
   const [startDate, setStartDate] = useState(() => {
-    const d = new Date(); d.setMonth(0, 1); return d.toISOString().slice(0, 10);
+    const d = new Date(); d.setMonth(0, 1); return toDateInputValue(d);
   });
-  const [endDate, setEndDate] = useState(() => new Date().toISOString().slice(0, 10));
+  const [endDate, setEndDate] = useState(() => toDateInputValue(new Date()));
   const [category, setCategory] = useState<QBImportCategory>("wages");
 
   const importMutation = trpc.rdTaxCredit.importFromQuickBooks.useMutation({
-    onSuccess: (data: any) => {
+    onSuccess: (data) => {
       toast.success(`Imported ${data.imported ?? 0} expense(s) from QuickBooks`);
       setOpen(false);
       onRefresh();
     },
-    onError: (e: any) => toast.error(e.message),
+    onError: (e) => toast.error(e.message),
   });
 
   return (

--- a/scripts/strict-ratchet.mjs
+++ b/scripts/strict-ratchet.mjs
@@ -62,6 +62,21 @@ function runStrict() {
     if (output.trim()) console.error(output.trim());
     process.exit(2);
   }
+  // Now that exit code 2 is accepted, guard against diagnostics that carry no
+  // `file(line,col): error` prefix (e.g. an invalid tsconfig, "No inputs were
+  // found", TS5xxx option errors). Those parse to zero located errors, which
+  // would otherwise let the ratchet report a phantom improvement and pass green
+  // while the typecheck is actually broken. If tsc reported errors (status 1/2)
+  // but none are attributable to a file, treat it as a tooling failure.
+  if (r.status !== 0 && Object.keys(parseErrors(output)).length === 0) {
+    console.error(
+      "Strict typecheck reported errors, but none could be attributed to a " +
+        "file. This usually indicates a tsconfig/CLI problem; refusing to " +
+        "produce a baseline result from unparseable output.",
+    );
+    if (output.trim()) console.error(output.trim());
+    process.exit(2);
+  }
   return output;
 }
 


### PR DESCRIPTION
Follow-up to #296, addressing the Copilot review feedback left on #292. (#292's actual fixes already landed via #296, so it's being closed as superseded — this PR carries only the review-driven improvements, which apply to the code now live on `main`.)

## 1. Strict ratchet: fail fast on unparseable `tsc` output (`scripts/strict-ratchet.mjs`)

#296 made the ratchet accept `tsc` exit code `2` (cold incremental builds write `.tsbuildinfo` and exit 2 instead of 1). That's correct, but it widened a gap: if `tsc` emits diagnostics with **no** `file(line,col): error` prefix — an invalid tsconfig, `TS18003 No inputs were found`, `TS5xxx` option errors — `parseErrors()` returns `{}`, so the ratchet would see "0 errors", report a phantom improvement, and pass **green while the typecheck is actually broken**.

Fix: when `tsc` reports errors (status 1/2) but none are attributable to a file, treat it as a tooling failure and exit 2 instead of producing a baseline result from unparseable output.

## 2. R&D QuickBooks import dialog (`client/src/pages/finance/RdTaxCredit.tsx`)

- Default import date range used `toISOString().slice(0, 10)`, which formats in **UTC** and shifts the day by one for users in non-zero timezones — risky for an import date range. Switched to a local-time `YYYY-MM-DD` helper.
- Dropped the `any` annotations on the tRPC `onSuccess`/`onError` callbacks so the hook's inferred types apply (the mutation returns `{ imported, totalBills }`, so `data.imported` stays valid).

## Verification

- `pnpm check` — clean (0 errors)
- `pnpm strict:check` (cold, `.tsbuildinfo` deleted) — `Strict ratchet OK` (141 errors, baseline 142), exit 0
- Guard logic unit-checked: unlocated-only error output → fails fast; located errors → proceeds normally

https://claude.ai/code/session_01QV5EYi6eF7Sj7SQoPjypdY

---
_Generated by [Claude Code](https://claude.ai/code/session_01QV5EYi6eF7Sj7SQoPjypdY)_